### PR TITLE
[Documentation] README.md matrix fixes for ffuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,10 +295,10 @@ a few of the use-cases in which feroxbuster may be a better fit:
 | allows recursion                                    | ✔ |   | ✔ |
 | can specify query parameters                        | ✔ |   | ✔ |
 | SOCKS proxy support                                 | ✔ |   |   |
-| multiple target scan (via stdin or multiple -u)     | ✔ |   |   |
+| multiple target scan (via stdin or multiple -u)     | ✔ |   | ✔ |
 | configuration file for default value override       | ✔ |   | ✔ |
-| can accept urls via STDIN as part of a pipeline     | ✔ |   |   |
-| can accept wordlists via STDIN                      |   | ✔ |   |
+| can accept urls via STDIN as part of a pipeline     | ✔ |   | ✔ |
+| can accept wordlists via STDIN                      |   | ✔ | ✔ |
 | filter by response size                             | ✔ |   | ✔ |
 | auto-filter wildcard responses                      | ✔ |   | ✔ |
 | performs other scans (vhost, dns, etc)              |   | ✔ | ✔ |


### PR DESCRIPTION
Hi!

Thanks for releasing feroxbuster, it looks really fresh and has an intuitive approach to the job at hand ❤️ 

I had a look over at the README.md and have a few additions regarding `ffuf` functionalities to the comparison matrix. Some of them are a bit vague, so feel free to disagree and I'll change the PR accordingly. I'm trying to explain them here in the description.

- multiple target scan (via stdin or multiple -u)
  - As `ffuf` supports multiple wordlists, it's possible to use a wordlist for a list of hostnames. This list can also be supplied from STDIN (see the last entry in this list)
- can accept urls via STDIN as part of a pipeline
  - Same as the above
- can accept wordlists via STDIN
  - Ffuf can read wordlists (for hostnames, urls, headers whatever) from STDIN when using `-` as the wordlist path. This also supports optionally custom keywords (for example: `-w -:HOSTNAME`)

Your take on the column `ease to use` is absolutely on spot though 😆. 