### PR TITLE
added Dockerfile based on alpine. Includes wordlists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest
+LABEL maintainer="wfnintr@null.net"
+
+# download default wordlists 
+RUN apk add --no-cache --virtual .depends subversion && \
+	svn export https://github.com/danielmiessler/SecLists/trunk/Discovery/Web-Content /usr/share/seclists/Discovery/Web-Content && \
+	apk del .depends
+
+# install latest release
+RUN wget https://github.com/epi052/feroxbuster/releases/download/v1.0.0/x86_64-linux-feroxbuster.zip -qO feroxbuster.zip && unzip -d /usr/local/bin/ feroxbuster.zip feroxbuster && rm feroxbuster.zip && chmod +x /usr/local/bin/feroxbuster
+
+ENTRYPOINT ["feroxbuster"]


### PR DESCRIPTION
Docker container

- based on alpine
- uses latest release
- includes default wordlists cloned into `/usr/share/seclists`

### Example Basic usage
```
docker run --init -it feroxbuster -u http://example.com -x js,html
```

### Example Piping from stdin and proxying all requests through socks5 proxy
```
cat targets.txt | docker run --net=host --init -i feroxbuster --stdin -x js,html --proxy socks5://127.0.0.1:9050
```

### Define an alias for simplicity
```
alias feroxbuster="docker run --init -i feroxbuster"
```

