### PR TITLE
timeouts logged as warnings, other errors remain the same

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -223,7 +223,12 @@ pub async fn make_request(client: &Client, url: &Url) -> FeroxResult<Response> {
         }
         Err(e) => {
             log::trace!("exit: make_request -> {}", e);
-            log::error!("Error while making request: {}", e);
+            if e.to_string().contains("operation timed out") {
+                // only warn for timeouts, while actual errors are still left as errors
+                log::warn!("Error while making request: {}", e);
+            } else {
+                log::error!("Error while making request: {}", e);
+            }
             Err(Box::new(e))
         }
     }


### PR DESCRIPTION
# Landing a Pull Request (PR)

Long form explanations of most of the items below can be found in the [CONTRIBUTING](https://github.com/epi052/feroxbuster/blob/master/CONTRIBUTING.md) guide.

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123)
- [x] Code is in its own branch
- [x] Branch name is related to the PR contents
- [x] PR targets master

## Static analysis checks
- [x] All rust files are formatted using `cargo fmt`
- [x] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::unnecessary_unwrap`
- [x] All existing tests pass


