### PR TITLE
Publish to Arch User Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This attack is also known as Predictable Resource Location, File Enumeration, Di
     - [Homebrew on MacOS and Linux](#homebrew-on-macos-and-linux)
     - [Cargo Install](#cargo-install)
     - [apt Install](#apt-install)
+    - [AUR Install](#aur-install)
     - [Docker Install](#docker-install)
 - [Configuration](#-configuration)
     - [Default Values](#default-values)
@@ -160,6 +161,14 @@ Download `feroxbuster_amd64.deb` from the [Releases](https://github.com/epi052/f
 wget -sLO https://github.com/epi052/feroxbuster/releases/latest/download/feroxbuster_amd64.deb.zip
 unzip feroxbuster_amd64.deb.zip
 sudo apt install ./feroxbuster_amd64.deb
+```
+
+### AUR Install
+
+Install `feroxbuster` on Arch Linux with your AUR helper of choice:
+
+```
+yay -S feroxbuster
 ```
 
 ### Docker Install


### PR DESCRIPTION
Hi, I love Feroxbuster and wanted to help more users access it so as an Arch Linux user, I [published it to the AUR](https://aur.archlinux.org/packages/feroxbuster/) (Arch User Repository) under the package name `feroxbuster`.

This pull requests just appends to the installation instructions of the README.md telling users how they can install it from Arch Linux.

Thank you for making an awesome project! If you have an AUR account and would like me to transfer ownership of the package to you, I'd be happy to do that as well.