### PR TITLE
Update AUR Package Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ sudo apt install ./feroxbuster_amd64.deb
 
 ### AUR Install
 
-Install `feroxbuster` on Arch Linux with your AUR helper of choice:
+Install `feroxbuster-git` on Arch Linux with your AUR helper of choice:
 
 ```
-yay -S feroxbuster
+yay -S feroxbuster-git
 ```
 
 ### Docker Install


### PR DESCRIPTION
I've had to change the AUR package name from `feroxbuster` to [`feroxbuster-git`](https://aur.archlinux.org/packages/feroxbuster-git) in order to meet Arch Linux's [VCS package guidelines](https://wiki.archlinux.org/index.php/VCS_package_guidelines). This pull request just updates the package name in the README so that users download the correct package (the old one will soon be unavailable).