### PR TITLE
add ability to resume scans

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Long form explanations of most of the items below can be found in the [CONTRIBUT
 
 ## Static analysis checks
 - [ ] All rust files are formatted using `cargo fmt`
-- [ ] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::deref_addrof`
+- [ ] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings`
 - [ ] All existing tests pass
 
 ## Documentation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Long form explanations of most of the items below can be found in the [CONTRIBUT
 
 ## Static analysis checks
 - [ ] All rust files are formatted using `cargo fmt`
-- [ ] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::deref_addrof`
 - [ ] All existing tests pass
 
 ## Documentation

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,4 +61,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --all-features -- -D warnings -A clippy::unnecessary_unwrap -A clippy::deref_addrof
+          args: --all-targets --all-features -- -D warnings

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,4 +61,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --all-features -- -D warnings
+          args: --all-targets --all-features -- -D warnings -A clippy::deref_addrof

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feroxbuster"
-version = "1.8.0"
+version = "1.9.0"
 authors = ["Ben 'epi' Risher <epibar052@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ dirs = "3.0"
 regex = "1"
 crossterm = "0.18"
 rlimit = "0.5"
+ctrlc = "3.1"
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/ferox-config.toml.example
+++ b/ferox-config.toml.example
@@ -36,6 +36,7 @@
 # filter_word_count = [993]
 # filter_line_count = [35, 36]
 # queries = [["name","value"], ["rick", "astley"]]
+# save_state = false
 
 # headers can be specified on multiple lines or as an inline table
 #

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,7 @@ lazy_static! {
     pub static ref PROGRESS_BAR: MultiProgress = MultiProgress::with_draw_target(ProgressDrawTarget::stdout());
 
     /// Global progress bar that is only used for printing messages that don't jack up other bars
-    pub static ref PROGRESS_PRINTER: ProgressBar = progress::add_bar("", 0, true);
+    pub static ref PROGRESS_PRINTER: ProgressBar = progress::add_bar("", 0, true, false);
 }
 
 /// simple helper to clean up some code reuse below; panics under test / exits in prod
@@ -192,9 +192,19 @@ pub struct Configuration {
     /// Don't auto-filter wildcard responses
     #[serde(default)]
     pub dont_filter: bool,
+
+    /// Scan started from a state file, not from CLI args
+    #[serde(default)]
+    pub resumed: bool,
+
+    /// Whether or not a scan's current state should be saved when user presses Ctrl+C
+    ///
+    /// Not configurable from CLI; can only be set from a config file
+    #[serde(default = "save_state")]
+    pub save_state: bool,
 }
 
-// functions timeout, threads, status_codes, user_agent, wordlist, and depth are used to provide
+// functions timeout, threads, status_codes, user_agent, wordlist, save_state, and depth are used to provide
 // defaults in the event that a ferox-config.toml is found but one or more of the values below
 // aren't listed in the config.  This way, we get the correct defaults upon Deserialization
 
@@ -206,6 +216,11 @@ fn serialized_type() -> String {
 /// default timeout value
 fn timeout() -> u64 {
     7
+}
+
+/// default save_state value
+fn save_state() -> bool {
+    true
 }
 
 /// default threads value
@@ -257,6 +272,7 @@ impl Default for Configuration {
             replay_client,
             dont_filter: false,
             quiet: false,
+            resumed: false,
             stdin: false,
             json: false,
             verbosity: 0,
@@ -266,6 +282,7 @@ impl Default for Configuration {
             redirects: false,
             no_recursion: false,
             extract_links: false,
+            save_state: true,
             proxy: String::new(),
             config: String::new(),
             output: String::new(),
@@ -305,6 +322,7 @@ impl Configuration {
     /// - **output**: `None` (print to stdout)
     /// - **debug_log**: `None`
     /// - **quiet**: `false`
+    /// - **save_state**: `true`
     /// - **user_agent**: `feroxbuster/VERSION`
     /// - **insecure**: `false` (don't be insecure, i.e. don't allow invalid certs)
     /// - **extensions**: `None`
@@ -353,6 +371,16 @@ impl Configuration {
             // when resuming a scan, instead of normal configuration loading, we just
             // load the config from disk by calling resume_scan
             let mut previous_config = resume_scan(filename);
+
+            // the resumed flag isn't printed in the banner and really has no business being
+            // serialized or included in much of the usual config logic; simply setting it to true
+            // here and being done with it
+            previous_config.resumed = true;
+
+            // if the user used --stdin, we already have all the scans started (or complete), we
+            // need to flip stdin to false so that the 'read from stdin' logic doesn't fire (if
+            // not flipped to false, the program hangs waiting for input from stdin again)
+            previous_config.stdin = false;
 
             // clients aren't serialized, have to remake them from the previous config
             Self::try_rebuild_clients(&mut previous_config);
@@ -596,6 +624,7 @@ impl Configuration {
             || configuration.redirects
             || configuration.insecure
             || !configuration.headers.is_empty()
+            || configuration.resumed
         {
             if configuration.proxy.is_empty() {
                 configuration.client = client::initialize(
@@ -681,6 +710,7 @@ impl Configuration {
         settings.scan_limit = settings_to_merge.scan_limit;
         settings.replay_proxy = settings_to_merge.replay_proxy;
         settings.replay_codes = settings_to_merge.replay_codes;
+        settings.save_state = settings_to_merge.save_state;
         settings.debug_log = settings_to_merge.debug_log;
         settings.json = settings_to_merge.json;
     }
@@ -781,6 +811,7 @@ mod tests {
             dont_filter = true
             extract_links = true
             json = true
+            save_state = false
             depth = 1
             filter_size = [4120]
             filter_regex = ["^ignore me$"]
@@ -816,6 +847,7 @@ mod tests {
         assert_eq!(config.dont_filter, false);
         assert_eq!(config.no_recursion, false);
         assert_eq!(config.json, false);
+        assert_eq!(config.save_state, true);
         assert_eq!(config.stdin, false);
         assert_eq!(config.add_slash, false);
         assert_eq!(config.redirects, false);
@@ -1018,6 +1050,13 @@ mod tests {
     fn config_reads_filter_status() {
         let config = setup_config_test();
         assert_eq!(config.filter_status, vec![201]);
+    }
+
+    #[test]
+    /// parse the test config and see that the value parsed is correct
+    fn config_reads_save_state() {
+        let config = setup_config_test();
+        assert_eq!(config.save_state, false);
     }
 
     #[test]

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -360,6 +360,8 @@ mod tests {
             wildcard: true,
             url: Url::parse("http://localhost").unwrap(),
             content_length: 100,
+            word_count: 50,
+            line_count: 25,
             headers: reqwest::header::HeaderMap::new(),
             status: reqwest::StatusCode::OK,
         };
@@ -380,6 +382,8 @@ mod tests {
             wildcard: true,
             url: Url::parse("http://localhost/stuff").unwrap(),
             content_length: 100,
+            word_count: 50,
+            line_count: 25,
             headers: reqwest::header::HeaderMap::new(),
             status: reqwest::StatusCode::OK,
         };
@@ -400,6 +404,8 @@ mod tests {
             wildcard: false,
             url: Url::parse("http://localhost/stuff").unwrap(),
             content_length: 100,
+            word_count: 50,
+            line_count: 25,
             headers: reqwest::header::HeaderMap::new(),
             status: reqwest::StatusCode::OK,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use reqwest::{header::HeaderMap, Response, StatusCode, Url};
 use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
 use std::{error, fmt};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -409,8 +409,8 @@ impl<'de> Deserialize<'de> for FeroxResponse {
                     }
                 }
                 "status" => {
-                    if let Some(num) = value.as_str() {
-                        if let Ok(smaller) = u16::from_str(num) {
+                    if let Some(num) = value.as_u64() {
+                        if let Ok(smaller) = u16::try_from(num) {
                             if let Ok(status) = StatusCode::from_u16(smaller) {
                                 response.status = status;
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,6 +192,7 @@ async fn wrapped_main() {
 
     // get targets from command line or stdin
     let targets = match get_targets().await {
+        // todo when resuming a scan, this probably doesnt make sense (need to alter get_targets?)
         Ok(t) => t,
         Err(e) => {
             // should only happen in the event that there was an error reading from stdin
@@ -204,8 +205,9 @@ async fn wrapped_main() {
     if !CONFIGURATION.quiet {
         // only print banner if -q isn't used
         let std_stderr = stderr(); // std::io::stderr
-        log::error!("WTF {:?}", *CONFIGURATION);  // todo remove after banner fixed
+        log::error!("WTF {:?}", *CONFIGURATION); // todo remove after banner fixed
         banner::initialize(&targets, &CONFIGURATION, &VERSION, std_stderr).await;
+        // todo probably print RESPONSES here
     }
 
     // discard non-responsive targets

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use feroxbuster::{
     banner,
     config::{CONFIGURATION, PROGRESS_BAR, PROGRESS_PRINTER},
     heuristics, logger, reporter,
-    scan_manager::PAUSE_SCAN,
+    scan_manager::{self, PAUSE_SCAN},
     scanner::{self, scan_url},
     utils::{ferox_print, get_current_depth, module_colorizer, status_colorizer},
     FeroxError, FeroxResponse, FeroxResult, SLEEP_DURATION, VERSION,
@@ -297,6 +297,9 @@ async fn clean_up(
 fn main() {
     // setup logging based on the number of -v's used
     logger::initialize(CONFIGURATION.verbosity);
+
+    // start the ctrl+c handler
+    scan_manager::initialize();
 
     // this function uses rlimit, which is not supported on windows
     #[cfg(not(target_os = "windows"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,6 +204,7 @@ async fn wrapped_main() {
     if !CONFIGURATION.quiet {
         // only print banner if -q isn't used
         let std_stderr = stderr(); // std::io::stderr
+        log::error!("WTF {:?}", *CONFIGURATION);  // todo remove after banner fixed
         banner::initialize(&targets, &CONFIGURATION, &VERSION, std_stderr).await;
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -131,6 +131,13 @@ pub fn initialize() -> App<'static, 'static> {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("resume_from")
+                .long("resume-from")
+                .value_name("FILE")
+                .help("State file from which to resume a partially complete scan")
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("debug_log")
                 .long("debug-log")
                 .value_name("FILE")

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -305,6 +305,7 @@ pub fn initialize() -> App<'static, 'static> {
         )
         .group(ArgGroup::with_name("output_files")
             .args(&["debug_log", "output"])
+            .multiple(true)
         )
         .after_help(r#"NOTE:
     Options that take multiple values are very flexible.  Consider the following ways of specifying

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,5 @@
 use crate::VERSION;
-use clap::{App, Arg};
+use clap::{App, Arg, ArgGroup};
 
 /// Create and return an instance of [clap::App](https://docs.rs/clap/latest/clap/struct.App.html), i.e. the Command Line Interface's configuration
 pub fn initialize() -> App<'static, 'static> {
@@ -19,7 +19,7 @@ pub fn initialize() -> App<'static, 'static> {
             Arg::with_name("url")
                 .short("u")
                 .long("url")
-                .required_unless("stdin")
+                .required_unless_one(&["stdin", "resume_from"])
                 .value_name("URL")
                 .multiple(true)
                 .use_delimiter(true)
@@ -113,6 +113,7 @@ pub fn initialize() -> App<'static, 'static> {
             Arg::with_name("json")
                 .long("json")
                 .takes_value(false)
+                .requires("output_files")
                 .help("Emit JSON logs to --output and --debug-log instead of normal text")
         )
         .arg(
@@ -133,8 +134,9 @@ pub fn initialize() -> App<'static, 'static> {
         .arg(
             Arg::with_name("resume_from")
                 .long("resume-from")
-                .value_name("FILE")
-                .help("State file from which to resume a partially complete scan")
+                .value_name("STATE_FILE")
+                .help("State file from which to resume a partially complete scan (ex. --resume-from ferox-1606586780.state)")
+                .conflicts_with_all(&["wordlist", "url", "threads", "depth", "timeout", "verbosity", "proxy", "replay_proxy", "replay_codes", "status_codes", "quiet", "json", "dont_filter", "output", "debug_log", "user_agent", "redirects", "insecure", "extensions", "headers", "queries", "no_recursion", "add_slash", "stdin", "filter_size", "filter_regex", "filter_words", "filter_lines", "filter_status", "extract_links", "scan_limit"])
                 .takes_value(true),
         )
         .arg(
@@ -300,6 +302,9 @@ pub fn initialize() -> App<'static, 'static> {
                 .value_name("SCAN_LIMIT")
                 .takes_value(true)
                 .help("Limit total number of concurrent scans (default: 0, i.e. no limit)")
+        )
+        .group(ArgGroup::with_name("output_files")
+            .args(&["debug_log", "output"])
         )
         .after_help(r#"NOTE:
     Options that take multiple values are very flexible.  Consider the following ways of specifying

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -39,8 +39,12 @@ mod tests {
         let p2 = add_bar("prefix", 2, false, true); // no per second field
         let p3 = add_bar("prefix", 2, false, false); // normal bar
 
-        assert!(p1.is_hidden());
-        assert!(!p2.is_hidden());
-        assert!(!p3.is_hidden());
+        p1.finish();
+        p2.finish();
+        p3.finish();
+
+        assert!(p1.is_finished());
+        assert!(p2.is_finished());
+        assert!(p3.is_finished());
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -3,9 +3,16 @@ use indicatif::{ProgressBar, ProgressStyle};
 
 /// Add an [indicatif::ProgressBar](https://docs.rs/indicatif/latest/indicatif/struct.ProgressBar.html)
 /// to the global [PROGRESS_BAR](../config/struct.PROGRESS_BAR.html)
-pub fn add_bar(prefix: &str, length: u64, hidden: bool) -> ProgressBar {
+pub fn add_bar(prefix: &str, length: u64, hidden: bool, hide_per_sec: bool) -> ProgressBar {
     let style = if hidden || CONFIGURATION.quiet {
         ProgressStyle::default_bar().template("")
+    } else if hide_per_sec {
+        ProgressStyle::default_bar()
+            .template(&format!(
+                "[{{bar:.cyan/blue}}] - {{elapsed:<4}} {{pos:>7}}/{{len:7}} {:7} {{prefix}}",
+                "-"
+            ))
+            .progress_chars("#>-")
     } else {
         ProgressStyle::default_bar()
             .template("[{bar:.cyan/blue}] - {elapsed:<4} {pos:>7}/{len:7} {per_sec:7} {prefix}")

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -27,3 +27,20 @@ pub fn add_bar(prefix: &str, length: u64, hidden: bool, hide_per_sec: bool) -> P
 
     progress_bar
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// hit all code branches for add_bar
+    fn add_bar_with_all_configurations() {
+        let p1 = add_bar("prefix", 2, true, false); // hidden
+        let p2 = add_bar("prefix", 2, false, true); // no per second field
+        let p3 = add_bar("prefix", 2, false, false); // normal bar
+
+        assert!(p1.is_hidden());
+        assert!(!p2.is_hidden());
+        assert!(!p3.is_hidden());
+    }
+}

--- a/src/scan_manager.rs
+++ b/src/scan_manager.rs
@@ -972,18 +972,14 @@ mod tests {
         };
 
         let expected_strs = predicates::str::contains("scans:").and(
-            predicate::str::contains(saved_id.to_string())
+            predicate::str::contains("config: Configuration")
                 .and(predicate::str::contains("https://nerdcore.com/css"))
-                .and(predicate::str::contains("scan_type: Directory"))
-                .and(predicate::str::contains("https://nerdcore.com/css"))
-                .and(predicate::str::contains("content_length: 173"))
-                .and(predicate::str::contains("line_count: 10"))
-                .and(predicate::str::contains(r#"{"server": "nginx/1.16.1"}"#))
-                .and(predicate::str::contains(
-                    r#"config: Configuration { kind: "configuration""#,
-                )),
+                .and(predicate::str::contains("https://spiritanimal.com"))
+                .and(predicate::str::contains("scans: FeroxScans"))
+                .and(predicate::str::contains("responses: FeroxResponses")),
         );
 
+        println!("{}", ferox_state.as_str());
         assert!(expected_strs.eval(&ferox_state.as_str()));
 
         let json_state = ferox_state.as_json();

--- a/src/scan_manager.rs
+++ b/src/scan_manager.rs
@@ -905,4 +905,29 @@ mod tests {
             serde_json::to_string(&ferox_scans).unwrap()
         );
     }
+
+    #[test]
+    /// given a FeroxResponse, test that it serializes into the proper JSON entry
+    fn ferox_response_serialize_and_deserialize() {
+        // deserialize
+        let json_response = r#"{"type":"response","url":"https://nerdcore.com/css","path":"/css","wildcard":true,"status":301,"content_length":173,"line_count":10,"word_count":16,"headers":{"referrer-policy":"origin-when-cross-origin","server":"nginx/1.16.1"}}"#;
+        let response: FeroxResponse = serde_json::from_str(json_response).unwrap();
+
+        assert_eq!(response.url.as_str(), "https://nerdcore.com/css");
+        assert_eq!(response.url.path(), "/css");
+        assert_eq!(response.wildcard, true);
+        assert_eq!(response.status.as_u16(), 301);
+        assert_eq!(response.content_length, 173);
+        assert_eq!(response.line_count, 10);
+        assert_eq!(response.word_count, 16);
+        assert_eq!(response.headers.get("server").unwrap(), "nginx/1.16.1");
+        assert_eq!(
+            response.headers.get("referrer-policy").unwrap(),
+            "origin-when-cross-origin"
+        );
+
+        // serialize, however, this can fail when headers are out of order
+        let new_json = serde_json::to_string(&response).unwrap();
+        assert_eq!(json_response, new_json);
+    }
 }

--- a/src/scan_manager.rs
+++ b/src/scan_manager.rs
@@ -601,7 +601,11 @@ pub fn initialize() {
 
         let slug = if !CONFIGURATION.target_url.is_empty() {
             // target url populated
-            CONFIGURATION.target_url.replace("://", "_").replace("/", "_").replace(".", "_")
+            CONFIGURATION
+                .target_url
+                .replace("://", "_")
+                .replace("/", "_")
+                .replace(".", "_")
         } else {
             // stdin used
             "stdin".to_string()

--- a/src/scan_manager.rs
+++ b/src/scan_manager.rs
@@ -910,7 +910,7 @@ mod tests {
     /// given a FeroxResponse, test that it serializes into the proper JSON entry
     fn ferox_response_serialize_and_deserialize() {
         // deserialize
-        let json_response = r#"{"type":"response","url":"https://nerdcore.com/css","path":"/css","wildcard":true,"status":301,"content_length":173,"line_count":10,"word_count":16,"headers":{"referrer-policy":"origin-when-cross-origin","server":"nginx/1.16.1"}}"#;
+        let json_response = r#"{"type":"response","url":"https://nerdcore.com/css","path":"/css","wildcard":true,"status":301,"content_length":173,"line_count":10,"word_count":16,"headers":{"server":"nginx/1.16.1"}}"#;
         let response: FeroxResponse = serde_json::from_str(json_response).unwrap();
 
         assert_eq!(response.url.as_str(), "https://nerdcore.com/css");
@@ -921,10 +921,6 @@ mod tests {
         assert_eq!(response.line_count, 10);
         assert_eq!(response.word_count, 16);
         assert_eq!(response.headers.get("server").unwrap(), "nginx/1.16.1");
-        assert_eq!(
-            response.headers.get("referrer-policy").unwrap(),
-            "origin-when-cross-origin"
-        );
 
         // serialize, however, this can fail when headers are out of order
         let new_json = serde_json::to_string(&response).unwrap();

--- a/src/scan_manager.rs
+++ b/src/scan_manager.rs
@@ -971,15 +971,14 @@ mod tests {
             config: &CONFIGURATION,
         };
 
-        let expected_strs = predicates::str::contains("scans:").and(
+        let expected_strs = predicates::str::contains("scans: FeroxScans").and(
             predicate::str::contains("config: Configuration")
-                .and(predicate::str::contains("https://nerdcore.com/css"))
-                .and(predicate::str::contains("https://spiritanimal.com"))
-                .and(predicate::str::contains("scans: FeroxScans"))
-                .and(predicate::str::contains("responses: FeroxResponses")),
+                .and(predicate::str::contains("responses: FeroxResponses"))
+                .and(predicate::str::contains("nerdcore.com"))
+                .and(predicate::str::contains("/css"))
+                .and(predicate::str::contains("https://spiritanimal.com")),
         );
 
-        println!("{}", ferox_state.as_str());
         assert!(expected_strs.eval(&ferox_state.as_str()));
 
         let json_state = ferox_state.as_json();

--- a/src/scan_manager.rs
+++ b/src/scan_manager.rs
@@ -841,4 +841,30 @@ mod tests {
         assert!(scan.progress_bar.is_some()); // new pb created
         assert!(!pb.is_finished()) // not finished
     }
+
+    #[test]
+    /// given a JSON entry representing a FeroxScan, test that it deserializes into the proper type
+    /// with the right attributes
+    fn ferox_scan_deserialize() {
+        // let fs = FeroxScan::new("http://spiritanimal.com", ScanType::Directory, None);
+        let fs_json = r#"{"id":"057016a14769414aac9a7a62707598cb","url":"https://spiritanimal.com","scan_type":"Directory","complete":true}"#;
+
+        let fs: FeroxScan = serde_json::from_str(fs_json).unwrap();
+        assert_eq!(fs.url, "https://spiritanimal.com");
+
+        match fs.scan_type {
+            ScanType::Directory => {}
+            ScanType::File => {
+                panic!();
+            }
+        }
+        match fs.progress_bar {
+            None => {}
+            Some(_) => {
+                panic!();
+            }
+        }
+        assert_eq!(fs.complete, true);
+        assert_eq!(fs.id, "057016a14769414aac9a7a62707598cb");
+    }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -6,7 +6,7 @@ use crate::{
         WordsFilter,
     },
     heuristics,
-    scan_manager::{FeroxScans, PAUSE_SCAN},
+    scan_manager::{FeroxResponses, FeroxScans, PAUSE_SCAN},
     utils::{format_url, get_current_depth, make_request},
     FeroxChannel, FeroxResponse,
 };
@@ -46,6 +46,9 @@ lazy_static! {
 
     /// Vector of implementors of the FeroxFilter trait
     static ref FILTERS: Arc<RwLock<Vec<Box<dyn FeroxFilter>>>> = Arc::new(RwLock::new(Vec::<Box<dyn FeroxFilter>>::new()));
+
+    /// Vector of FeroxResponse objects
+    pub static ref RESPONSES: FeroxResponses = FeroxResponses::default();
 
     /// Bounded semaphore used as a barrier to limit concurrent scans
     static ref SCAN_LIMITER: Semaphore = Semaphore::new(CONFIGURATION.scan_limit);

--- a/tests/test_banner.rs
+++ b/tests/test_banner.rs
@@ -711,6 +711,8 @@ fn banner_prints_json() {
         .arg("--url")
         .arg("http://localhost")
         .arg("--json")
+        .arg("--output")
+        .arg("/dev/null")
         .assert()
         .success()
         .stderr(

--- a/tests/test_scan_manager.rs
+++ b/tests/test_scan_manager.rs
@@ -1,0 +1,75 @@
+mod utils;
+use assert_cmd::Command;
+use httpmock::Method::GET;
+use httpmock::{Mock, MockServer};
+use predicates::prelude::*;
+use utils::{setup_tmp_directory, teardown_tmp_directory};
+
+#[test]
+/// pass a known serialized scan with 1 scan complete and 1 not. expect the incomplete scan to
+/// start and the complete to not start. expect the responses, scans, and configuration structures
+/// to be populated based off the contents of the given state file
+fn resume_scan_works() {
+    let srv = MockServer::start();
+    let (tmp_dir, file) = setup_tmp_directory(&["css".to_string(), "stuff".to_string()], "wordlist").unwrap();
+
+    // localhost:PORT/ <- complete
+    // localhost:PORT/js <- will get scanned with /css and /stuff
+    let complete_scan = format!(r#"{{"id":"057016a14769414aac9a7a62707598cb","url":"{}","scan_type":"Directory","complete":true}}"#, srv.url("/"));
+    let incomplete_scan = format!(r#"{{"id":"400b2323a16f43468a04ffcbbeba34c6","url":"{}","scan_type":"Directory","complete":false}}"#, srv.url("/js"));
+    let scans = format!(r#""scans":[{},{}]"#, complete_scan, incomplete_scan);
+
+    let config = format!(r#""config": {{"type":"configuration","wordlist":"{}","config":"","proxy":"","replay_proxy":"","target_url":"{}","status_codes":[200,204,301,302,307,308,401,403,405],"replay_codes":[200,204,301,302,307,308,401,403,405],"filter_status":[],"threads":50,"timeout":7,"verbosity":0,"quiet":false,"json":false,"output":"","debug_log":"","user_agent":"feroxbuster/1.9.0","redirects":false,"insecure":false,"extensions":[],"headers":{{}},"queries":[],"no_recursion":false,"extract_links":false,"add_slash":false,"stdin":false,"depth":2,"scan_limit":1,"filter_size":[],"filter_line_count":[],"filter_word_count":[],"filter_regex":[],"dont_filter":false}}"#, file.to_string_lossy(), srv.url("/"));
+
+    // // localhost:PORT/js/css has already been seen, expect not to be scanned
+    let response = format!(r#"{{"type":"response","url":"{}","path":"/js/css","wildcard":true,"status":301,"content_length":173,"line_count":10,"word_count":16,"headers":{{"server":"nginx/1.16.1"}}}}"#, srv.url("/js/css"));
+    let responses = format!(r#""responses":[{}]"#, response);
+
+    // not scanned because /js is not complete, and /js/stuff response is not known
+    let not_scanned_yet = Mock::new()
+        .expect_method(GET)
+        .expect_path("/js/stuff")
+        .return_status(200)
+        .return_body("i expect to be scanned")
+        .create_on(&srv);
+
+    // will get scanned because /js is not complete, but because response of /js/css is known, the
+    // response will not be in stdout
+    let already_scanned = Mock::new()
+        .expect_method(GET)
+        .expect_path("/js/css")
+        .return_status(200)
+        .create_on(&srv);
+
+    // already scanned because scan on / is complete
+    let also_already_scanned = Mock::new()
+        .expect_method(GET)
+        .expect_path("/css")
+        .return_status(200)
+        .return_body("two words")
+        .create_on(&srv);
+
+    let state_file_contents = format!("{{{},{},{}}}", scans, config, responses);
+    let (tmp_dir2, state_file) = setup_tmp_directory(&[state_file_contents], "state-file").unwrap();
+
+    Command::cargo_bin("feroxbuster")
+        .unwrap()
+        .arg("--resume-from")
+        .arg(state_file.as_os_str())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("/js/stuff")
+            .and(predicate::str::contains("22c"))
+            .and(predicate::str::contains("5w"))
+            .and(predicate::str::contains("/js/css")).not()
+            .and(predicate::str::contains("2w")).not()
+            .and(predicate::str::contains("9c")).not()
+        );
+
+    teardown_tmp_directory(tmp_dir);
+    teardown_tmp_directory(tmp_dir2);
+
+    assert_eq!(already_scanned.times_called(), 1);
+    assert_eq!(also_already_scanned.times_called(), 0);
+    assert_eq!(not_scanned_yet.times_called(), 1);
+}

--- a/tests/test_scan_manager.rs
+++ b/tests/test_scan_manager.rs
@@ -11,18 +11,32 @@ use utils::{setup_tmp_directory, teardown_tmp_directory};
 /// to be populated based off the contents of the given state file
 fn resume_scan_works() {
     let srv = MockServer::start();
-    let (tmp_dir, file) = setup_tmp_directory(&["css".to_string(), "stuff".to_string()], "wordlist").unwrap();
+    let (tmp_dir, file) =
+        setup_tmp_directory(&["css".to_string(), "stuff".to_string()], "wordlist").unwrap();
 
     // localhost:PORT/ <- complete
     // localhost:PORT/js <- will get scanned with /css and /stuff
-    let complete_scan = format!(r#"{{"id":"057016a14769414aac9a7a62707598cb","url":"{}","scan_type":"Directory","complete":true}}"#, srv.url("/"));
-    let incomplete_scan = format!(r#"{{"id":"400b2323a16f43468a04ffcbbeba34c6","url":"{}","scan_type":"Directory","complete":false}}"#, srv.url("/js"));
+    let complete_scan = format!(
+        r#"{{"id":"057016a14769414aac9a7a62707598cb","url":"{}","scan_type":"Directory","complete":true}}"#,
+        srv.url("/")
+    );
+    let incomplete_scan = format!(
+        r#"{{"id":"400b2323a16f43468a04ffcbbeba34c6","url":"{}","scan_type":"Directory","complete":false}}"#,
+        srv.url("/js")
+    );
     let scans = format!(r#""scans":[{},{}]"#, complete_scan, incomplete_scan);
 
-    let config = format!(r#""config": {{"type":"configuration","wordlist":"{}","config":"","proxy":"","replay_proxy":"","target_url":"{}","status_codes":[200,204,301,302,307,308,401,403,405],"replay_codes":[200,204,301,302,307,308,401,403,405],"filter_status":[],"threads":50,"timeout":7,"verbosity":0,"quiet":false,"json":false,"output":"","debug_log":"","user_agent":"feroxbuster/1.9.0","redirects":false,"insecure":false,"extensions":[],"headers":{{}},"queries":[],"no_recursion":false,"extract_links":false,"add_slash":false,"stdin":false,"depth":2,"scan_limit":1,"filter_size":[],"filter_line_count":[],"filter_word_count":[],"filter_regex":[],"dont_filter":false}}"#, file.to_string_lossy(), srv.url("/"));
+    let config = format!(
+        r#""config": {{"type":"configuration","wordlist":"{}","config":"","proxy":"","replay_proxy":"","target_url":"{}","status_codes":[200,204,301,302,307,308,401,403,405],"replay_codes":[200,204,301,302,307,308,401,403,405],"filter_status":[],"threads":50,"timeout":7,"verbosity":0,"quiet":false,"json":false,"output":"","debug_log":"","user_agent":"feroxbuster/1.9.0","redirects":false,"insecure":false,"extensions":[],"headers":{{}},"queries":[],"no_recursion":false,"extract_links":false,"add_slash":false,"stdin":false,"depth":2,"scan_limit":1,"filter_size":[],"filter_line_count":[],"filter_word_count":[],"filter_regex":[],"dont_filter":false}}"#,
+        file.to_string_lossy(),
+        srv.url("/")
+    );
 
     // // localhost:PORT/js/css has already been seen, expect not to be scanned
-    let response = format!(r#"{{"type":"response","url":"{}","path":"/js/css","wildcard":true,"status":301,"content_length":173,"line_count":10,"word_count":16,"headers":{{"server":"nginx/1.16.1"}}}}"#, srv.url("/js/css"));
+    let response = format!(
+        r#"{{"type":"response","url":"{}","path":"/js/css","wildcard":true,"status":301,"content_length":173,"line_count":10,"word_count":16,"headers":{{"server":"nginx/1.16.1"}}}}"#,
+        srv.url("/js/css")
+    );
     let responses = format!(r#""responses":[{}]"#, response);
 
     // not scanned because /js is not complete, and /js/stuff response is not known
@@ -58,12 +72,16 @@ fn resume_scan_works() {
         .arg(state_file.as_os_str())
         .assert()
         .success()
-        .stdout(predicate::str::contains("/js/stuff")
-            .and(predicate::str::contains("22c"))
-            .and(predicate::str::contains("5w"))
-            .and(predicate::str::contains("/js/css")).not()
-            .and(predicate::str::contains("2w")).not()
-            .and(predicate::str::contains("9c")).not()
+        .stdout(
+            predicate::str::contains("/js/stuff")
+                .and(predicate::str::contains("22c"))
+                .and(predicate::str::contains("5w"))
+                .and(predicate::str::contains("/js/css"))
+                .not()
+                .and(predicate::str::contains("2w"))
+                .not()
+                .and(predicate::str::contains("9c"))
+                .not(),
         );
 
     teardown_tmp_directory(tmp_dir);


### PR DESCRIPTION
closes #144 

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123)
- [x] Code is in its own branch
- [x] Branch name is related to the PR contents
- [x] PR targets master

## Static analysis checks
- [x] All rust files are formatted using `cargo fmt`
- [x] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::deref_addrof`
- [x] All existing tests pass

## Documentation
- [x] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [x] Documentation about your PR is included in the README, as needed

## Additional Tests
- [x] New code is unit tested
- [x] New code is integration tested, as needed
- [x] New tests pass

## Sub Features
- [x] User can set a value in the config to not drop state files on ctrl+c
- [x] `--resume-scan` should be mutually exclusive with everything (ideally)