### PR TITLE
fixed issue where only one initial feroxscan was issued

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feroxbuster"
-version = "1.10.2"
+version = "1.10.3"
 authors = ["Ben 'epi' Risher <epibar052@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,7 @@ async fn scan(
     }
 
     let mut tasks = vec![];
+    let num_targets = targets.len();
 
     for target in targets {
         let word_clone = words.clone();
@@ -184,7 +185,15 @@ async fn scan(
 
         let task = tokio::spawn(async move {
             let base_depth = get_current_depth(&target);
-            scan_url(&target, word_clone, base_depth, term_clone, file_clone).await;
+            scan_url(
+                &target,
+                word_clone,
+                base_depth,
+                num_targets,
+                term_clone,
+                file_clone,
+            )
+            .await;
         });
 
         tasks.push(task);


### PR DESCRIPTION
closes #169 

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123456)
- [x] Code is in its own branch
- [x] Branch name is related to the PR contents
- [x] PR targets master

## Static analysis checks
- [x] All rust files are formatted using `cargo fmt`
- [x] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::deref_addrof`
- [x] All existing tests pass

## Documentation
- [x] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)

## Additional Tests
- [x] New code is unit tested
- [x] New code is integration tested, as needed
- [x] New tests pass
