### PR TITLE
added small check for help param to always print and exit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,10 @@ name: CD Pipeline
 
 on: [push]
 
-env:
-  IN_PIPELINE: true
-
 jobs:
   build-nix:
+    env:
+      IN_PIPELINE: true
     runs-on: ${{ matrix.os }}
     if: github.ref == 'refs/heads/main'
     strategy:
@@ -87,6 +86,8 @@ jobs:
           path: ./target/x86_64-unknown-linux-musl/debian/*
 
   build-macos:
+    env:
+      IN_PIPELINE: true
     runs-on: macos-latest
     if: github.ref == 'refs/heads/main'
     steps:
@@ -117,6 +118,8 @@ jobs:
           path: x86_64-macos-feroxbuster.tar.gz
 
   build-windows:
+    env:
+      IN_PIPELINE: true
     runs-on: ${{ matrix.os }}
     if: github.ref == 'refs/heads/main'
     strategy:
@@ -149,4 +152,3 @@ jobs:
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.path }}
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feroxbuster"
-version = "2.2.4"
+version = "2.2.5"
 authors = ["Ben 'epi' Risher <epibar052@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,8 @@
 use clap::{App, Arg, ArgGroup};
 use lazy_static::lazy_static;
 use regex::Regex;
+use std::env;
+use std::process;
 
 lazy_static! {
     /// Regex used to validate values passed to --time-limit
@@ -16,7 +18,7 @@ lazy_static! {
 
 /// Create and return an instance of [clap::App](https://docs.rs/clap/latest/clap/struct.App.html), i.e. the Command Line Interface's configuration
 pub fn initialize() -> App<'static, 'static> {
-    App::new("feroxbuster")
+    let mut app = App::new("feroxbuster")
         .version(env!("CARGO_PKG_VERSION"))
         .author("Ben 'epi' Risher (@epi052)")
         .about("A fast, simple, recursive content discovery tool written in Rust")
@@ -410,7 +412,20 @@ EXAMPLES:
 
     Ludicrous speed... go!
         ./feroxbuster -u http://127.1 -t 200
-    "#)
+    "#);
+
+    for arg in env::args() {
+        // secure-77 noticed that when an incorrect flag/option is used, the short help message is printed
+        // which is fine, but if you add -h|--help, it still errors out on the bad flag/option,
+        // never showing the full help message. This code addresses that behavior
+        if arg == "--help" || arg == "-h" {
+            app.print_long_help().unwrap();
+            println!(); // just a newline to mirror original --help output
+            process::exit(1);
+        }
+    }
+
+    app
 }
 
 /// Validate that a string is formatted as a number followed by s, m, h, or d (10d, 30s, etc...)

--- a/tests/test_parser.rs
+++ b/tests/test_parser.rs
@@ -1,0 +1,46 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+/// specify an incorrect param (-fc) with --help after it on the command line
+/// old behavior printed
+/// error: Found argument '-c' which wasn't expected, or isn't valid in this context
+///
+/// USAGE:
+///     feroxbuster --add-slash --url <URL>...
+///
+/// For more information try --help
+///
+/// the new behavior we expect to see is to print the long form help message, of which
+/// Ludicrous speed... go! is near the bottom of that output, so we can test for that
+fn parser_incorrect_param_with_tack_tack_help() {
+    Command::cargo_bin("feroxbuster")
+        .unwrap()
+        .arg("-fc")
+        .arg("--help")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("Ludicrous speed... go!"));
+}
+
+#[test]
+/// specify an incorrect param (-fc) with --help after it on the command line
+/// old behavior printed
+/// error: Found argument '-c' which wasn't expected, or isn't valid in this context
+///
+/// USAGE:
+///     feroxbuster --add-slash --url <URL>...
+///
+/// For more information try --help
+///
+/// the new behavior we expect to see is to print the long form help message, of which
+/// Ludicrous speed... go! is near the bottom of that output, so we can test for that
+fn parser_incorrect_param_with_tack_h() {
+    Command::cargo_bin("feroxbuster")
+        .unwrap()
+        .arg("-fc")
+        .arg("-h")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("Ludicrous speed... go!"));
+}


### PR DESCRIPTION
# Landing a Pull Request (PR)

Long form explanations of most of the items below can be found in the [CONTRIBUTING](https://github.com/epi052/feroxbuster/blob/master/CONTRIBUTING.md) guide.
fixes #287 

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123456)
- [x] Code is in its own branch
- [x] Branch name is related to the PR contents
- [x] PR targets main

## Static analysis checks
- [x] All rust files are formatted using `cargo fmt`
- [x] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::mutex-atomic`
- [x] All existing tests pass

## Documentation
- [x] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [x] Documentation about your PR is included in the README, as needed

## Additional Tests
- [x] New code is unit tested
- [x] New code is integration tested, as needed
- [x] New tests pass
