### PR TITLE
Log to separate files when using --parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "feroxbuster"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feroxbuster"
-version = "2.3.1"
+version = "2.3.2"
 authors = ["Ben 'epi' Risher <epibar052@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1011,7 +1011,7 @@ feroxbuster --stdin --parallel 10
  \_ feroxbuster --silent --extract-links --auto-bail -u https://target-ten
 ```
 
-As of `v2.3.2`, logging while using `--parallel` () uses the value of `-o`|`--output` as a seed to create a directory named `OUTPUT_VALUE-TIMESTAMP.logs/`. Within the directory, an individual log file is created for each target passed over stdin.
+As of `v2.3.2`, logging while using `--parallel` uses the value of `-o`|`--output` as a seed to create a directory named `OUTPUT_VALUE-TIMESTAMP.logs/`. Within the directory, an individual log file is created for each target passed over stdin.
 
 Example Command:
 ```

--- a/README.md
+++ b/README.md
@@ -1011,6 +1011,21 @@ feroxbuster --stdin --parallel 10
  \_ feroxbuster --silent --extract-links --auto-bail -u https://target-ten
 ```
 
+As of `v2.3.2`, logging while using `--parallel` () uses the value of `-o`|`--output` as a seed to create a directory named `OUTPUT_VALUE-TIMESTAMP.logs/`. Within the directory, an individual log file is created for each target passed over stdin.
+
+Example Command:
+```
+cat large-target-list | ./feroxbuster --stdin --parallel 10 --output super-cool-mega-scan
+```
+
+Resulting directory structure (illustrative):
+```
+super-cool-mega-scan-1627865696.logs/
+├── ferox-https_target_one_com-1627865696.log
+├── ...
+└── ferox-https_target_two_net-1627865696.log
+```
+
 ### Prevent Specific Domain/Directory Scans aka a Deny List (new in `v2.3.0`)
 
 > This action is taken BEFORE a request is sent to the target, which differs from the filter-* options that are applied to responses

--- a/src/event_handlers/inputs.rs
+++ b/src/event_handlers/inputs.rs
@@ -79,10 +79,10 @@ impl TermInputHandler {
 
         let filename = if !handles.config.target_url.is_empty() {
             // target url populated
-            slugify_filename(&handles.config.target_url, "state")
+            slugify_filename(&handles.config.target_url, "ferox", "state")
         } else {
             // stdin used
-            slugify_filename("stdin", "state")
+            slugify_filename("stdin", "ferox", "state")
         };
 
         let warning = format!(

--- a/src/event_handlers/inputs.rs
+++ b/src/event_handlers/inputs.rs
@@ -4,6 +4,7 @@ use crate::{
     scan_manager::{FeroxState, PAUSE_SCAN},
     scanner::RESPONSES,
     statistics::StatError,
+    utils::slugify_filename,
     utils::{open_file, write_to},
     SLEEP_DURATION,
 };
@@ -17,7 +18,6 @@ use std::{
     },
     thread::sleep,
     time::Duration,
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 /// Atomic boolean flag, used to determine whether or not the terminal input handler should exit
@@ -77,22 +77,14 @@ impl TermInputHandler {
     pub fn sigint_handler(handles: Arc<Handles>) -> Result<()> {
         log::trace!("enter: sigint_handler({:?})", handles);
 
-        let ts = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-
-        let slug = if !handles.config.target_url.is_empty() {
+        let filename = if !handles.config.target_url.is_empty() {
             // target url populated
-            handles
-                .config
-                .target_url
-                .replace("://", "_")
-                .replace("/", "_")
-                .replace(".", "_")
+            slugify_filename(&handles.config.target_url, "state")
         } else {
             // stdin used
-            "stdin".to_string()
+            slugify_filename("stdin", "state")
         };
 
-        let filename = format!("ferox-{}-{}.state", slug, ts);
         let warning = format!(
             "🚨 Caught {} 🚨 saving scan state to {} ...",
             style("ctrl+c").yellow(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,14 +272,17 @@ async fn wrapped_main(config: Arc<Configuration>) -> Result<()> {
         // of -o|--output.
         let out_dir = if !config.output.is_empty() {
             // -o|--output was used, so we'll attempt to create a directory to store the files
+            let base_name = Path::new(&handles.config.output).file_name().unwrap(); // todo remove unwrap
 
-            let folder = slugify_filename(&handles.config.output, "", "logs");
+            let new_folder = slugify_filename(&base_name.to_string_lossy(), "", "logs");
+
+            let final_path = Path::new(&handles.config.output).with_file_name(&new_folder); // todo too many path::new calls
 
             // create the directory or fail silently, assuming the reason for failure is that
             // the path exists already
-            create_dir(&folder).unwrap_or(());
+            create_dir(&final_path).unwrap_or(());
 
-            folder
+            final_path.to_string_lossy().to_string()
         } else {
             String::new()
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 use std::{
     env::args,
-    fs::File,
+    fs::{create_dir, remove_file, File},
     io::{stderr, BufRead, BufReader},
     ops::Index,
+    path::Path,
     process::Command,
     sync::{atomic::Ordering, Arc},
 };
@@ -27,10 +28,10 @@ use feroxbuster::{
     progress::{PROGRESS_BAR, PROGRESS_PRINTER},
     scan_manager::{self},
     scanner,
-    utils::fmt_err,
+    utils::{fmt_err, set_open_file_limit, slugify_filename},
+    DEFAULT_OPEN_FILE_LIMIT,
 };
 #[cfg(not(target_os = "windows"))]
-use feroxbuster::{utils::set_open_file_limit, DEFAULT_OPEN_FILE_LIMIT};
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -267,10 +268,49 @@ async fn wrapped_main(config: Arc<Configuration>) -> Result<()> {
         // from removing --parallel)
         original.remove(parallel_index);
 
+        // to log unique files to a shared folder, we need to first check for the presence
+        // of -o|--output.
+        let out_dir = if !config.output.is_empty() {
+            // -o|--output was used, so we'll attempt to create a directory to store the files
+
+            let folder = slugify_filename(&handles.config.output, "logs");
+
+            // create the directory or fail silently, assuming the reason for failure is that
+            // the path exists already
+            create_dir(&folder).unwrap_or(());
+
+            folder
+        } else {
+            String::new()
+        };
+
         // unvalidated targets fresh from stdin, just spawn children and let them do all checks
         for target in targets {
             // add the current target to the provided command
             let mut cloned = original.clone();
+
+            if !out_dir.is_empty() {
+                // output directory value is not empty, need to join output directory with
+                // unique scan filename
+
+                // unwrap is ok, we already know -o was used
+                let out_idx = original
+                    .iter()
+                    .position(|s| *s == "--output" || *s == "-o")
+                    .unwrap();
+
+                let filename = slugify_filename(&target, "log");
+
+                let full_path = Path::new(&out_dir)
+                    .join(filename)
+                    .to_string_lossy()
+                    .to_string();
+
+                // a +1 to the index is fine here, as clap has already validated that
+                // -o|--output has a value associated with it
+                cloned[out_idx + 1] = full_path;
+            }
+
             cloned.push("-u".to_string());
             cloned.push(target);
 
@@ -294,7 +334,21 @@ async fn wrapped_main(config: Arc<Configuration>) -> Result<()> {
             });
         }
 
+        // the output handler creates an empty file to which it will try to write, because
+        // this happens before we enter the --parallel branch, we need to remove that file
+        // if it's empty
+        let output = handles.config.output.to_owned();
+
         clean_up(handles, tasks).await?;
+
+        let file = Path::new(&output);
+        if file.exists() {
+            // expectation is that this is always true for the first ferox process
+            if file.metadata()?.len() == 0 {
+                // empty file, attempt to remove it
+                remove_file(file)?;
+            }
+        }
 
         log::trace!("exit: parallel branch && wrapped main");
         return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,11 +272,15 @@ async fn wrapped_main(config: Arc<Configuration>) -> Result<()> {
         // of -o|--output.
         let out_dir = if !config.output.is_empty() {
             // -o|--output was used, so we'll attempt to create a directory to store the files
-            let base_name = Path::new(&handles.config.output).file_name().unwrap(); // todo remove unwrap
+            let output_path = Path::new(&handles.config.output);
+
+            // this only returns None if the path terminates in `..`. Since I don't want to
+            // hand-hold to that degree, we'll unwrap and fail if the output path ends in `..`
+            let base_name = output_path.file_name().unwrap();
 
             let new_folder = slugify_filename(&base_name.to_string_lossy(), "", "logs");
 
-            let final_path = Path::new(&handles.config.output).with_file_name(&new_folder); // todo too many path::new calls
+            let final_path = output_path.with_file_name(&new_folder);
 
             // create the directory or fail silently, assuming the reason for failure is that
             // the path exists already

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,7 +273,7 @@ async fn wrapped_main(config: Arc<Configuration>) -> Result<()> {
         let out_dir = if !config.output.is_empty() {
             // -o|--output was used, so we'll attempt to create a directory to store the files
 
-            let folder = slugify_filename(&handles.config.output, "logs");
+            let folder = slugify_filename(&handles.config.output, "", "logs");
 
             // create the directory or fail silently, assuming the reason for failure is that
             // the path exists already
@@ -299,7 +299,7 @@ async fn wrapped_main(config: Arc<Configuration>) -> Result<()> {
                     .position(|s| *s == "--output" || *s == "-o")
                     .unwrap();
 
-                let filename = slugify_filename(&target, "log");
+                let filename = slugify_filename(&target, "ferox", "log");
 
                 let full_path = Path::new(&out_dir)
                     .join(filename)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,6 +8,8 @@ use std::{
     fs,
     io::{self, BufWriter, Write},
     sync::Arc,
+    time::Duration,
+    time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -382,6 +384,26 @@ pub fn should_deny_url(url: &Url, handles: Arc<Handles>) -> Result<bool> {
     }
     log::trace!("exit: should_deny_url -> false");
     Ok(false)
+}
+
+/// given a url and filename-suffix, return a unique filename comprised of the slugified url,
+/// current unix timestamp and suffix
+///
+/// ex: ferox-http_telsa_com-1606947491.state
+pub fn slugify_filename(url: &str, suffix: &str) -> String {
+    log::trace!("enter: slugify({:?}, {:?})", url, suffix);
+
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0))
+        .as_secs();
+
+    let slug = url.replace("://", "_").replace("/", "_").replace(".", "_");
+
+    let filename = format!("ferox-{}-{}.{}", slug, ts, suffix);
+
+    log::trace!("exit: slugify -> {}", filename);
+    filename
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -390,17 +390,23 @@ pub fn should_deny_url(url: &Url, handles: Arc<Handles>) -> Result<bool> {
 /// current unix timestamp and suffix
 ///
 /// ex: ferox-http_telsa_com-1606947491.state
-pub fn slugify_filename(url: &str, suffix: &str) -> String {
-    log::trace!("enter: slugify({:?}, {:?})", url, suffix);
+pub fn slugify_filename(url: &str, prefix: &str, suffix: &str) -> String {
+    log::trace!("enter: slugify({:?}, {:?}, {:?})", url, prefix, suffix);
 
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_else(|_| Duration::from_secs(0))
         .as_secs();
 
+    let altered_prefix = if !prefix.is_empty() {
+        format!("{}-", prefix)
+    } else {
+        String::new()
+    };
+
     let slug = url.replace("://", "_").replace("/", "_").replace(".", "_");
 
-    let filename = format!("ferox-{}-{}.{}", slug, ts, suffix);
+    let filename = format!("{}{}-{}.{}", altered_prefix, slug, ts, suffix);
 
     log::trace!("exit: slugify -> {}", filename);
     filename

--- a/tests/test_main.rs
+++ b/tests/test_main.rs
@@ -3,7 +3,7 @@ use assert_cmd::Command;
 use httpmock::Method::GET;
 use httpmock::{MockServer, Regex};
 use predicates::prelude::*;
-use std::fs::read_to_string;
+use std::fs::{read_dir, read_to_string};
 use utils::{setup_tmp_directory, teardown_tmp_directory};
 
 #[test]
@@ -146,6 +146,76 @@ fn main_parallel_spawns_children() -> Result<(), Box<dyn std::error::Error>> {
     assert!(r1.is_match(&contents)); // all 3 were spawned
     assert!(r2.is_match(&contents));
     assert!(r3.is_match(&contents));
+
+    teardown_tmp_directory(word_tmp_dir);
+    teardown_tmp_directory(tgt_tmp_dir);
+    teardown_tmp_directory(output_dir);
+
+    Ok(())
+}
+
+#[test]
+/// send three targets over stdin with --output enabled, expect parallel to create a new directory
+/// and the log files therein
+fn main_parallel_creates_output_directory() -> Result<(), Box<dyn std::error::Error>> {
+    let t1 = MockServer::start();
+    let t2 = MockServer::start();
+    let t3 = MockServer::start();
+
+    let words = [
+        String::from("LICENSE"),
+        String::from("stuff"),
+        String::from("things"),
+        String::from("mostuff"),
+        String::from("mothings"),
+    ];
+    let (word_tmp_dir, wordlist) = setup_tmp_directory(&words, "wordlist")?;
+    let (output_dir, outfile) = setup_tmp_directory(&[], "output-file")?;
+    let (tgt_tmp_dir, targets) =
+        setup_tmp_directory(&[t1.url("/"), t2.url("/"), t3.url("/")], "targets")?;
+
+    Command::cargo_bin("feroxbuster")
+        .unwrap()
+        .arg("--stdin")
+        .arg("--parallel")
+        .arg("2")
+        .arg("--output")
+        .arg(outfile.as_os_str())
+        .arg("--wordlist")
+        .arg(wordlist.as_os_str())
+        .pipe_stdin(targets)
+        .unwrap()
+        .assert()
+        .success()
+        .stderr(
+            predicate::str::contains("Could not connect to any target provided")
+                .and(predicate::str::contains("Target Url"))
+                .not(), // no target url found
+        );
+
+    // output_dir should return something similar to output-file-1627845244.logs with the
+    // line below. if it ever fails, can use the regex below to filter out the right directory
+    let sub_dir = read_dir(&output_dir)?.next().unwrap()?.file_name();
+
+    let mut num_logs = 0;
+    let file_regex = Regex::new("ferox-[a-zA-Z_:0-9]+-[0-9]+.log").unwrap();
+    let dir_regex = Regex::new("output-file-[0-9]+.logs").unwrap();
+
+    let sub_dir = output_dir.as_ref().join(&sub_dir);
+
+    // created directory like output-file-1627845741.logs/
+    assert!(dir_regex.is_match(&sub_dir.to_string_lossy().to_string()));
+
+    for entry in sub_dir.read_dir()? {
+        let entry = entry?;
+        // created each file like ferox-https_localhost-1627845741.log
+        println!("name: {:?}", entry.file_name().to_string_lossy());
+        assert!(file_regex.is_match(&entry.file_name().to_string_lossy()));
+        num_logs += 1;
+    }
+
+    // should be 3 log files total
+    assert_eq!(num_logs, 3);
 
     teardown_tmp_directory(word_tmp_dir);
     teardown_tmp_directory(tgt_tmp_dir);


### PR DESCRIPTION
closes #319 

# Landing a Pull Request (PR)

Long form explanations of most of the items below can be found in the [CONTRIBUTING](https://github.com/epi052/feroxbuster/blob/master/CONTRIBUTING.md) guide.

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123456)
- [x] Code is in its own branch
- [x] Branch name is related to the PR contents
- [x] PR targets main

## Static analysis checks
- [x] All rust files are formatted using `cargo fmt`
- [x] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::mutex-atomic`
- [x] All existing tests pass

## Documentation
- [x] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [x] Documentation about your PR is included in the README, as needed

## Additional Tests
- [x] New code is unit tested
- [x] New code is integration tested, as needed
- [x] New tests pass
