### PR TITLE
Optimize Dockerfile and implement CI/CD to DockerHub

### DIFF
--- a/.github/workflows/cicd-to-dockerhub.yml
+++ b/.github/workflows/cicd-to-dockerhub.yml
@@ -1,0 +1,36 @@
+name: ci-to-dockerhub
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/feroxbuster:latest
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,30 @@
-FROM alpine:latest
+# Image: alpine:3.14.2
+FROM alpine@sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a as build
 LABEL maintainer="wfnintr@null.net"
 
-RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories && apk upgrade --update-cache --available
+RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories \
+    && apk upgrade --update-cache --available
 
-# download default wordlists 
-RUN apk add --no-cache --virtual .depends subversion font-noto-emoji && \
-	svn export https://github.com/danielmiessler/SecLists/trunk/Discovery/Web-Content /usr/share/seclists/Discovery/Web-Content && \
-	apk del .depends
+# Download default wordlists 
+RUN apk add --no-cache --virtual .depends subversion font-noto-emoji \
+    && svn export https://github.com/danielmiessler/SecLists/trunk/Discovery/Web-Content /usr/share/seclists/Discovery/Web-Content
 
-# install latest release
-RUN wget https://github.com/epi052/feroxbuster/releases/latest/download/x86_64-linux-feroxbuster.zip -qO feroxbuster.zip && unzip -d /usr/local/bin/ feroxbuster.zip feroxbuster && rm feroxbuster.zip && chmod +x /usr/local/bin/feroxbuster
+# Download latest release
+RUN wget https://github.com/epi052/feroxbuster/releases/latest/download/x86_64-linux-feroxbuster.zip -qO feroxbuster.zip \
+    && unzip -d /usr/local/bin/ feroxbuster.zip feroxbuster \
+    && chmod +x /usr/local/bin/feroxbuster
+
+# Image: alpine:3.14.2
+FROM alpine@sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a as release
+
+COPY --from=build /usr/share/seclists/Discovery/Web-Content /usr/share/seclists/Discovery/Web-Content
+COPY --from=build /usr/local/bin/feroxbuster /usr/local/bin/feroxbuster
+
+RUN adduser \
+    --gecos "" \
+    --disabled-password \
+    feroxbuster
+
+USER feroxbuster
 
 ENTRYPOINT ["feroxbuster"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,20 +5,17 @@ LABEL maintainer="wfnintr@null.net"
 RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories \
     && apk upgrade --update-cache --available
 
-# Download default wordlists 
-RUN apk add --no-cache --virtual .depends subversion font-noto-emoji \
-    && svn export https://github.com/danielmiessler/SecLists/trunk/Discovery/Web-Content /usr/share/seclists/Discovery/Web-Content
-
 # Download latest release
 RUN wget https://github.com/epi052/feroxbuster/releases/latest/download/x86_64-linux-feroxbuster.zip -qO feroxbuster.zip \
-    && unzip -d /usr/local/bin/ feroxbuster.zip feroxbuster \
-    && chmod +x /usr/local/bin/feroxbuster
+    && unzip -d /tmp/ feroxbuster.zip feroxbuster \
+    && chmod +x /tmp/feroxbuster \
+    && wget https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/Web-Content/raft-medium-directories.txt -O /tmp/raft-medium-directories.txt
 
 # Image: alpine:3.14.2
 FROM alpine@sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a as release
 
-COPY --from=build /usr/share/seclists/Discovery/Web-Content /usr/share/seclists/Discovery/Web-Content
-COPY --from=build /usr/local/bin/feroxbuster /usr/local/bin/feroxbuster
+COPY --from=build /tmp/raft-medium-directories.txt /usr/share/seclists/Discovery/Web-Content/raft-medium-directories.txt
+COPY --from=build /tmp/feroxbuster /usr/local/bin/feroxbuster
 
 RUN adduser \
     --gecos "" \


### PR DESCRIPTION
This PR fixes and modifies the Dockerfile in feroxbuster with the following considerations:
- Adds deterministic base images for reproducible builds.
- Adds a multi-stage build that reduces the image size from about 78MB to 13MB.
- Added a least-privileged user in compliance with Docker security best practices.

We also have a workflow with a CICD pipeline to DockerHub. All you need to do is to add the DOCKER_HUB_USERNAME and DOCKER_HUB_ACCESS_TOKEN secrets to the repository and all pushes/merges to the master branch will automatically push an image to DockerHub.