### PR TITLE
adding support add_slash and extensions + correcting error on double slashes in the start of a word with extension

### DIFF
--- a/src/heuristics.rs
+++ b/src/heuristics.rs
@@ -156,7 +156,13 @@ impl HeuristicTests {
         log::trace!("enter: make_wildcard_request({}, {})", target, length);
 
         let unique_str = self.unique_string(length);
-        let nonexistent_url = target.format(&unique_str, None)?;
+        // To take care of slash when needed
+        let slash = if self.handles.config.add_slash {
+            Some("/")
+        } else {
+            None
+        };
+        let nonexistent_url = target.format(&unique_str,  slash)?;
 
         let response = logged_request(&nonexistent_url.to_owned(), self.handles.clone()).await?;
 

--- a/src/heuristics.rs
+++ b/src/heuristics.rs
@@ -162,7 +162,7 @@ impl HeuristicTests {
         } else {
             None
         };
-        let nonexistent_url = target.format(&unique_str,  slash)?;
+        let nonexistent_url = target.format(&unique_str, slash)?;
 
         let response = logged_request(&nonexistent_url.to_owned(), self.handles.clone()).await?;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -265,7 +265,6 @@ pub fn initialize() -> App<'static, 'static> {
                 .short("f")
                 .long("add-slash")
                 .takes_value(false)
-                .conflicts_with("extensions")
                 .help("Append / to each request")
         )
         .arg(

--- a/src/url.rs
+++ b/src/url.rs
@@ -101,10 +101,9 @@ impl FeroxUrl {
         };
 
         // extensions and slashes are now not mutually exclusive cases
-        let mut word = if extension.is_some() {
+        let mut word = if let Some(ext) = extension {
             // We handle the special case of forward slash
             // That allow us to treat it as an extension with a particular format
-            let ext = extension.unwrap();
             if ext == "/" {
                 format!("{}/", word)
             } else {

--- a/src/url.rs
+++ b/src/url.rs
@@ -497,6 +497,5 @@ mod tests {
             Ok(urls) => assert_eq!(urls.len(), 3), // 3 = One for the main word + slash and for the two extensions
             Err(err) => panic!("{}", err.to_string()),
         }
-
     }
 }


### PR DESCRIPTION
response to my two bug and feature enhancement ([#354](https://github.com/epi052/feroxbuster/issues/354), [#353](https://github.com/epi052/feroxbuster/issues/353)).

Sorry I didn't do everything correctly it is my first time.

# Landing a Pull Request (PR)

Long form explanations of most of the items below can be found in the [CONTRIBUTING](https://github.com/epi052/feroxbuster/blob/master/CONTRIBUTING.md) guide.

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123456)
- [ ] Code is in its own branch
- [x] Branch name is related to the PR contents
- [x] PR targets main

## Static analysis checks
- [x] All rust files are formatted using `cargo fmt`
- [x] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::mutex-atomic`
- [x] All existing tests pass

## Documentation
- [x] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [ ] Documentation about your PR is included in the README, as needed

## Additional Tests
- [x] New code is unit tested
- [x] New code is integration tested, as needed
- [x] New tests pass
