### PR TITLE
Added support for specifying cookies with the `-b` flag

### DIFF
--- a/shell_completions/_feroxbuster
+++ b/shell_completions/_feroxbuster
@@ -44,6 +44,8 @@ _feroxbuster() {
 '*--dont-scan=[URL(s) or Regex Pattern(s) to exclude from recursion/scans]' \
 '*-H+[Specify HTTP headers (ex: -H Header:val '\''stuff: things'\'')]' \
 '*--headers=[Specify HTTP headers (ex: -H Header:val '\''stuff: things'\'')]' \
+'*-b+[Specify HTTP cookies (ex: -b Cookie=val '\''stuff=things'\'')]' \
+'*--cookies=[Specify HTTP cookies (ex: -b Cookie=val '\''stuff=things'\'')]' \
 '*-Q+[Specify URL query parameters (ex: -Q token=stuff -Q secret=key)]' \
 '*--query=[Specify URL query parameters (ex: -Q token=stuff -Q secret=key)]' \
 '*-S+[Filter out messages of a particular size (ex: -S 5120 -S 4927,1970)]' \

--- a/shell_completions/_feroxbuster.ps1
+++ b/shell_completions/_feroxbuster.ps1
@@ -49,6 +49,8 @@ Register-ArgumentCompleter -Native -CommandName 'feroxbuster' -ScriptBlock {
             [CompletionResult]::new('--dont-scan', 'dont-scan', [CompletionResultType]::ParameterName, 'URL(s) or Regex Pattern(s) to exclude from recursion/scans')
             [CompletionResult]::new('-H', 'H', [CompletionResultType]::ParameterName, 'Specify HTTP headers (ex: -H Header:val ''stuff: things'')')
             [CompletionResult]::new('--headers', 'headers', [CompletionResultType]::ParameterName, 'Specify HTTP headers (ex: -H Header:val ''stuff: things'')')
+            [CompletionResult]::new('-b', 'b', [CompletionResultType]::ParameterName, 'Specify HTTP cookies (ex: -b Cookie=val ''stuff=things'')')
+            [CompletionResult]::new('--cookies', 'cookies', [CompletionResultType]::ParameterName, 'Specify HTTP cookies (ex: -b Cookie=val ''stuff=things'')')
             [CompletionResult]::new('-Q', 'Q', [CompletionResultType]::ParameterName, 'Specify URL query parameters (ex: -Q token=stuff -Q secret=key)')
             [CompletionResult]::new('--query', 'query', [CompletionResultType]::ParameterName, 'Specify URL query parameters (ex: -Q token=stuff -Q secret=key)')
             [CompletionResult]::new('-S', 'S', [CompletionResultType]::ParameterName, 'Filter out messages of a particular size (ex: -S 5120 -S 4927,1970)')

--- a/shell_completions/feroxbuster.bash
+++ b/shell_completions/feroxbuster.bash
@@ -20,7 +20,7 @@ _feroxbuster() {
 
     case "${cmd}" in
         feroxbuster)
-            opts=" -v -q -D -A -r -k -n -f -e -h -V -w -u -t -d -T -p -P -R -s -o -a -x -H -Q -S -X -W -N -C -L  --verbosity --silent --quiet --auto-tune --auto-bail --json --dont-filter --random-agent --redirects --insecure --no-recursion --add-slash --stdin --extract-links --help --version --wordlist --url --threads --depth --timeout --proxy --replay-proxy --replay-codes --status-codes --output --resume-from --debug-log --user-agent --extensions --dont-scan --headers --query --filter-size --filter-regex --filter-words --filter-lines --filter-status --filter-similar-to --scan-limit --parallel --rate-limit --time-limit  "
+            opts=" -v -q -D -A -r -k -n -f -e -h -V -w -u -t -d -T -p -P -R -s -o -a -x -H -b -Q -S -X -W -N -C -L  --verbosity --silent --quiet --auto-tune --auto-bail --json --dont-filter --random-agent --redirects --insecure --no-recursion --add-slash --stdin --extract-links --help --version --wordlist --url --threads --depth --timeout --proxy --replay-proxy --replay-codes --status-codes --output --resume-from --debug-log --user-agent --extensions --dont-scan --headers --cookies --query --filter-size --filter-regex --filter-words --filter-lines --filter-status --filter-similar-to --scan-limit --parallel --rate-limit --time-limit  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -140,6 +140,14 @@ _feroxbuster() {
                     return 0
                     ;;
                     -H)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --cookies)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -b)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/shell_completions/feroxbuster.fish
+++ b/shell_completions/feroxbuster.fish
@@ -14,6 +14,7 @@ complete -c feroxbuster -n "__fish_use_subcommand" -s a -l user-agent -d 'Sets t
 complete -c feroxbuster -n "__fish_use_subcommand" -s x -l extensions -d 'File extension(s) to search for (ex: -x php -x pdf js)'
 complete -c feroxbuster -n "__fish_use_subcommand" -l dont-scan -d 'URL(s) or Regex Pattern(s) to exclude from recursion/scans'
 complete -c feroxbuster -n "__fish_use_subcommand" -s H -l headers -d 'Specify HTTP headers (ex: -H Header:val \'stuff: things\')'
+complete -c feroxbuster -n "__fish_use_subcommand" -s b -l cookies -d 'Specify HTTP cookies (ex: -b Cookie=val \'stuff=things\')'
 complete -c feroxbuster -n "__fish_use_subcommand" -s Q -l query -d 'Specify URL query parameters (ex: -Q token=stuff -Q secret=key)'
 complete -c feroxbuster -n "__fish_use_subcommand" -s S -l filter-size -d 'Filter out messages of a particular size (ex: -S 5120 -S 4927,1970)'
 complete -c feroxbuster -n "__fish_use_subcommand" -s X -l filter-regex -d 'Filter out messages via regular expression matching on the response\'s body (ex: -X \'^ignore me$\')'

--- a/src/config/container.rs
+++ b/src/config/container.rs
@@ -725,6 +725,26 @@ impl Configuration {
             }
         }
 
+        // slightly modified version of the above header parsing block
+        if let Some(cookies) = args.values_of("cookies") {
+            for cookie in cookies {
+                match cookie.split('=').collect::<Vec<&str>>()[..] {
+                    // on splitting, there should be only two elements,
+                    // a key and a value
+                    // thus, using slice pattern matching
+                    [key, value] => {
+                        config.headers.insert(
+                            // we know the header name is always "cookie"
+                            "Cookie".to_string(),
+                            format!("{}={}", key.trim(), value.trim())
+                            // trim the spaces, join with an equals sign
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
+
         if let Some(queries) = args.values_of("queries") {
             for val in queries {
                 // same basic logic used as reading in the headers HashMap above

--- a/src/config/container.rs
+++ b/src/config/container.rs
@@ -725,23 +725,19 @@ impl Configuration {
             }
         }
 
-        // slightly modified version of the above header parsing block
         if let Some(cookies) = args.values_of("cookies") {
-            let mut parsed_cookies: Vec<String> = Vec::new();
-            for cookie in cookies {
-                if let [key, value] = cookie.split('=').collect::<Vec<&str>>()[..] {
-                    // on splitting, there should be only two elements,
-                    // a key and a value
-                    // thus, using slice pattern matching
-                    parsed_cookies.push(format!("{}={}", key.trim(), value.trim()));
-                    // trim the spaces, join with an equals sign
-                }
-            }
-            
             config.headers.insert(
-                    // we know the header name is always "cookie"
-                    "Cookie".to_string(),
-                    parsed_cookies.join("; ")
+                // we know the header name is always "cookie"
+                "Cookie".to_string(),
+                // on splitting, there should be only two elements,
+                // a key and a value
+                cookies.map(|cookie| cookie.split('=').collect::<Vec<&str>>()[..].to_owned())
+                .filter(|parts| parts.len() == 2)
+                .map(|parts| format!("{}={}", parts[0].trim(), parts[1].trim()))
+                // trim the spaces, join with an equals sign
+                .collect::<Vec<String>>()
+                .join("; ")
+                // join all the cookies with semicolons for the final header
             );
         }
 

--- a/src/config/container.rs
+++ b/src/config/container.rs
@@ -727,18 +727,22 @@ impl Configuration {
 
         // slightly modified version of the above header parsing block
         if let Some(cookies) = args.values_of("cookies") {
+            let mut parsed_cookies: Vec<String> = Vec::new();
             for cookie in cookies {
                 if let [key, value] = cookie.split('=').collect::<Vec<&str>>()[..] {
                     // on splitting, there should be only two elements,
                     // a key and a value
                     // thus, using slice pattern matching
-                    config.headers.insert(
-                        // we know the header name is always "cookie"
-                        "Cookie".to_string(),
-                        format!("{}={}", key.trim(), value.trim()), // trim the spaces, join with an equals sign
-                    );
+                    parsed_cookies.push(format!("{}={}", key.trim(), value.trim()));
+                    // trim the spaces, join with an equals sign
                 }
             }
+            
+            config.headers.insert(
+                    // we know the header name is always "cookie"
+                    "Cookie".to_string(),
+                    parsed_cookies.join("; ")
+            );
         }
 
         if let Some(queries) = args.values_of("queries") {

--- a/src/config/container.rs
+++ b/src/config/container.rs
@@ -728,19 +728,15 @@ impl Configuration {
         // slightly modified version of the above header parsing block
         if let Some(cookies) = args.values_of("cookies") {
             for cookie in cookies {
-                match cookie.split('=').collect::<Vec<&str>>()[..] {
+                if let [key, value] = cookie.split('=').collect::<Vec<&str>>()[..] {
                     // on splitting, there should be only two elements,
                     // a key and a value
                     // thus, using slice pattern matching
-                    [key, value] => {
-                        config.headers.insert(
-                            // we know the header name is always "cookie"
-                            "Cookie".to_string(),
-                            format!("{}={}", key.trim(), value.trim())
-                            // trim the spaces, join with an equals sign
-                        );
-                    }
-                    _ => {}
+                    config.headers.insert(
+                        // we know the header name is always "cookie"
+                        "Cookie".to_string(),
+                        format!("{}={}", key.trim(), value.trim()), // trim the spaces, join with an equals sign
+                    );
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,16 +51,12 @@ fn get_unique_words_from_wordlist(path: &str) -> Result<Arc<Vec<String>>> {
     let mut words = Vec::new();
 
     for line in reader.lines() {
-        let result = match line {
-            Ok(read_line) => read_line,
-            Err(_) => continue,
-        };
-
-        if result.starts_with('#') || result.is_empty() {
-            continue;
-        }
-
-        words.push(result);
+        line.map(|result| {
+            if !result.starts_with('#') && !result.is_empty() {
+                words.push(result);
+            }
+        })
+        .ok();
     }
 
     log::trace!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -251,6 +251,18 @@ pub fn initialize() -> App<'static, 'static> {
                 ),
         )
         .arg(
+            Arg::with_name("cookies")
+                .short("b")
+                .long("cookies")
+                .value_name("COOKIE")
+                .takes_value(true)
+                .multiple(true)
+                .use_delimiter(true)
+                .help(
+                    "Specify HTTP cookies (ex: -b Cookie=val 'stuff=things')",
+                ),
+        )
+        .arg(
             Arg::with_name("queries")
                 .short("Q")
                 .long("query")


### PR DESCRIPTION
I added some code to accept a `key=value` pair for cookies using the `--cookies` flag or the `-b` shorthand. The cookies can still be added using the longer `--header` flag way.


> I've written some code to implement this feature.

_Originally posted by @7047payloads in https://github.com/epi052/feroxbuster/issues/442#issuecomment-1004090323_