### PR TITLE
FIX 732 ensure --no-state is respected even through --time-limit

### DIFF
--- a/src/event_handlers/inputs.rs
+++ b/src/event_handlers/inputs.rs
@@ -101,10 +101,13 @@ impl TermInputHandler {
             handles.filters.data.clone(),
         );
 
-        let state_file = open_file(&filename);
+        // User didn't set the --no-state flag (so saved_state is still the default true)
+        if handles.config.save_state {
+            let state_file = open_file(&filename);
 
-        let mut buffered_file = state_file?;
-        write_to(&state, &mut buffered_file, true)?;
+            let mut buffered_file = state_file?;
+            write_to(&state, &mut buffered_file, true)?;
+        }
 
         log::trace!("exit: sigint_handler (end of program)");
         std::process::exit(1);


### PR DESCRIPTION
# Landing a Pull Request (PR)

Fixes [732](https://github.com/epi052/feroxbuster/issues/732)

Long form explanations of most of the items below can be found in the [CONTRIBUTING](https://github.com/epi052/feroxbuster/blob/master/CONTRIBUTING.md) guide.

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123456)
- [x] Code is in its own branch
- [x] Branch name is related to the PR contents
- [x] PR targets main

## Static analysis checks
- [x] All rust files are formatted using `cargo fmt`
- [x] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::mutex-atomic`
- [x] All existing tests pass

Not sure anything below this line applies but if so please let me know!

## Documentation
- [ ] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [ ] Documentation about your PR is included in the `docs`, as needed. The docs live in a [separate repository](https://epi052.github.io/feroxbuster-docs/docs/). Update the appropriate pages at the links below.
  - [ ] update [example config file section](https://epi052.github.io/feroxbuster-docs/docs/configuration/ferox-config-toml/)
  - [ ] update [help output section](https://epi052.github.io/feroxbuster-docs/docs/configuration/command-line/)
  - [ ] add an [example](https://epi052.github.io/feroxbuster-docs/docs/examples/)
  - [ ] update [comparison table](https://epi052.github.io/feroxbuster-docs/docs/compare/)

## Additional Tests
- [ ] New code is unit tested
- [ ] New code is integration tested, as needed
- [ ] New tests pass
