### PR TITLE
Fixes #761 | Updated Dockerfile and CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,35 +76,35 @@ Now that you have a copy of your fork, there is work you will need to do to keep
 
 Do this prior to every time you create a branch for a PR:
 
-1. Make sure you are on the `master` branch
+1. Make sure you are on the `main` branch
 
   > ```sh
   > $ git status
-  > On branch master
-  > Your branch is up-to-date with 'origin/master'.
+  > On branch main
+  > Your branch is up-to-date with 'origin/main'.
   > ```
 
-  > If your aren't on `master`, resolve outstanding files and commits and checkout the `master` branch
+  > If your aren't on `main`, resolve outstanding files and commits and checkout the `main` branch
 
   > ```sh
-  > $ git checkout master
+  > $ git checkout main
   > ```
 
 2. Do a pull with rebase against `upstream`
 
   > ```sh
-  > $ git pull --rebase upstream master
+  > $ git pull --rebase upstream main
   > ```
 
-  > This will pull down all of the changes to the official master branch, without making an additional commit in your local repo.
+  > This will pull down all of the changes to the official main branch, without making an additional commit in your local repo.
 
-3. (_Optional_) Force push your updated master branch to your GitHub fork
+3. (_Optional_) Force push your updated main branch to your GitHub fork
 
   > ```sh
-  > $ git push origin master --force
+  > $ git push origin main --force
   > ```
 
-  > This will overwrite the master branch of your fork.
+  > This will overwrite the main branch of your fork.
 
 ### Creating a branch
 
@@ -214,20 +214,20 @@ GitHub has a good guide on how to contribute to open source [here](https://opens
 
 ##### Editing via your local fork
 
-1.  Perform the maintenance step of rebasing `master`
-2.  Ensure you're on the `master` branch using `git status`:
+1.  Perform the maintenance step of rebasing `main`
+2.  Ensure you're on the `main` branch using `git status`:
 
 ```sh
 $ git status
-On branch master
-Your branch is up-to-date with 'origin/master'.
+On branch main
+Your branch is up-to-date with 'origin/main'.
 
 nothing to commit, working directory clean
 ```
 
-1.  If you're not on master or your working directory is not clean, resolve
-    any outstanding files/commits and checkout master `git checkout master`
-2.  Create a branch off of `master` with git: `git checkout -B
+1.  If you're not on main or your working directory is not clean, resolve
+    any outstanding files/commits and checkout main `git checkout main`
+2.  Create a branch off of `main` with git: `git checkout -B
     branch/name-here`
 3.  Edit your file(s) locally with the editor of your choice
 4.  Check your `git status` to see unstaged files
@@ -239,8 +239,8 @@ nothing to commit, working directory clean
 8.  Push your commits to your GitHub Fork: `git push -u origin branch/name-here`
 9.  Once the edits have been committed, you will be prompted to create a pull
     request on your fork's GitHub page
-10.  By default, all pull requests should be against the `master` branch
-11.  Submit a pull request from your branch to feroxbuster's `master` branch
+10.  By default, all pull requests should be against the `main` branch
+11.  Submit a pull request from your branch to feroxbuster's `main` branch
 12.  The title (also called the subject) of your PR should be descriptive of your
     changes and succinctly indicate what is being fixed
     -   Examples: `Add test cases for Unicode support`; `Correct typo in overview documentation`

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 FROM alpine@sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a as build
 LABEL maintainer="wfnintr@null.net"
 
-RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories \
-    && apk upgrade --update-cache --available && apk add --update openssl
+RUN apk upgrade --update-cache --available && apk add --update openssl
 
 
 # Download latest release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-# Image: alpine:3.14.2
-FROM alpine@sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a as build
+FROM alpine:3.17.1 as build
 LABEL maintainer="wfnintr@null.net"
 
 RUN apk upgrade --update-cache --available && apk add --update openssl
-
 
 # Download latest release
 RUN wget https://github.com/epi052/feroxbuster/releases/latest/download/x86_64-linux-feroxbuster.zip -qO feroxbuster.zip \
@@ -11,9 +9,7 @@ RUN wget https://github.com/epi052/feroxbuster/releases/latest/download/x86_64-l
     && chmod +x /tmp/feroxbuster \
     && wget https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/Web-Content/raft-medium-directories.txt -O /tmp/raft-medium-directories.txt
 
-# Image: alpine:3.14.2
-FROM alpine@sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a as release
-
+from alpine:3.17.1 as release
 COPY --from=build /tmp/raft-medium-directories.txt /usr/share/seclists/Discovery/Web-Content/raft-medium-directories.txt
 COPY --from=build /tmp/feroxbuster /usr/local/bin/feroxbuster
 


### PR DESCRIPTION
# Landing a Pull Request (PR)
Fixes #761
My first public PR, be gentle if I have managed to screw this up😄 

Long form explanations of most of the items below can be found in the [CONTRIBUTING](https://github.com/epi052/feroxbuster/blob/master/CONTRIBUTING.md) guide.

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123456)
- [x] Code is in its own branch
- [x] Branch name is related to the PR contents
- [x] PR targets main

## Static analysis checks
- [ ] All rust files are formatted using `cargo fmt`
- [ ] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::mutex-atomic`
- [ ] All existing tests pass

## Documentation
- [x] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [x] Documentation about your PR is included in the `docs`, as needed. The docs live in a [separate repository](https://epi052.github.io/feroxbuster-docs/docs/). Update the appropriate pages at the links below.
  - [ ] update [example config file section](https://epi052.github.io/feroxbuster-docs/docs/configuration/ferox-config-toml/)
  - [ ] update [help output section](https://epi052.github.io/feroxbuster-docs/docs/configuration/command-line/)
  - [ ] add an [example](https://epi052.github.io/feroxbuster-docs/docs/examples/)
  - [ ] update [comparison table](https://epi052.github.io/feroxbuster-docs/docs/compare/)

## Additional Tests
- [ ] New code is unit tested
- [ ] New code is integration tested, as needed
- [ ] New tests pass
