### PR TITLE
resume scan starts from offset in wordlist

### DIFF
--- a/src/event_handlers/command.rs
+++ b/src/event_handlers/command.rs
@@ -24,7 +24,9 @@ pub enum Command {
     AddStatus(StatusCode),
 
     /// Create the progress bar (`BarType::Total`) that is updated from the stats thread
-    CreateBar,
+    ///
+    /// the u64 value is the offset at which to start the progress bar (can be 0)
+    CreateBar(u64),
 
     /// Add to a `Stats` field that corresponds to the given `StatField` by the given `usize` value
     AddToUsizeField(StatField, usize),

--- a/src/event_handlers/scans.rs
+++ b/src/event_handlers/scans.rs
@@ -218,7 +218,7 @@ impl ScanHandler {
         // current number of requests expected per scan
         // ExpectedPerScan and TotalExpected are a += action, so we need the wordlist length to
         // update them while the other updates use expected_num_requests_per_dir
-        let num_words = self.get_wordlist()?.len();
+        let num_words = self.get_wordlist(0)?.len();
         let current_expectation = self.handles.expected_num_requests_per_dir() as u64;
 
         // used in the calculation of bar width down below, see explanation there
@@ -290,10 +290,19 @@ impl ScanHandler {
     }
 
     /// Helper to easily get the (locked) underlying wordlist
-    pub fn get_wordlist(&self) -> Result<Arc<Vec<String>>> {
+    pub fn get_wordlist(&self, offset: usize) -> Result<Arc<Vec<String>>> {
         if let Ok(guard) = self.wordlist.lock().as_ref() {
             if let Some(list) = guard.as_ref() {
-                return Ok(list.clone());
+                return if offset > 0 {
+                    // the offset could be off a bit, so we'll adjust it backwards by 10%
+                    // of the overall wordlist size to ensure we don't miss any words
+                    // (hopefully)
+                    let adjusted_offset = offset - ((offset as f64 * 0.10) as usize);
+
+                    Ok(Arc::new(list[adjusted_offset..].to_vec()))
+                } else {
+                    Ok(list.clone())
+                };
             }
         }
 
@@ -328,7 +337,7 @@ impl ScanHandler {
                 continue;
             }
 
-            let list = self.get_wordlist()?;
+            let list = self.get_wordlist(scan.requests() as usize)?;
 
             log::info!("scan handler received {} - beginning scan", target);
 

--- a/src/event_handlers/statistics.rs
+++ b/src/event_handlers/statistics.rs
@@ -115,8 +115,9 @@ impl StatsHandler {
                     }
                 }
                 Command::AddToF64Field(field, value) => self.stats.update_f64_field(field, value),
-                Command::CreateBar => {
+                Command::CreateBar(offset) => {
                     self.bar = add_bar("", self.stats.total_expected() as u64, BarType::Total);
+                    self.bar.set_position(offset);
                 }
                 Command::LoadStats(filename) => {
                     self.stats.merge_from(&filename)?;

--- a/src/scan_manager/scan.rs
+++ b/src/scan_manager/scan.rs
@@ -354,6 +354,7 @@ impl Serialize for FeroxScan {
         state.serialize_field("scan_type", &self.scan_type)?;
         state.serialize_field("status", &self.status)?;
         state.serialize_field("num_requests", &self.num_requests)?;
+        state.serialize_field("requests_made_so_far", &self.requests())?;
 
         state.end()
     }
@@ -367,6 +368,7 @@ impl<'de> Deserialize<'de> for FeroxScan {
         D: Deserializer<'de>,
     {
         let mut scan = Self::default();
+        let mut progress_bar_position = 0;
 
         let map: HashMap<String, Value> = HashMap::deserialize(deserializer)?;
 
@@ -412,9 +414,16 @@ impl<'de> Deserialize<'de> for FeroxScan {
                         scan.num_requests = num_requests;
                     }
                 }
+                "requests_made_so_far" => {
+                    if let Some(requests_made_so_far) = value.as_u64() {
+                        progress_bar_position = requests_made_so_far;
+                    }
+                }
                 _ => {}
             }
         }
+
+        scan.progress_bar().set_position(progress_bar_position);
 
         Ok(scan)
     }

--- a/src/scan_manager/scan.rs
+++ b/src/scan_manager/scan.rs
@@ -44,6 +44,12 @@ pub struct FeroxScan {
     /// Number of requests to populate the progress bar with
     pub(super) num_requests: u64,
 
+    /// Number of requests made so far, only used during deserialization
+    ///
+    /// serialization: saves self.requests() to this field
+    /// deserialization: sets self.requests_made_so_far to this field
+    pub(super) requests_made_so_far: u64,
+
     /// Status of this scan
     pub status: Mutex<ScanStatus>,
 
@@ -80,6 +86,7 @@ impl Default for FeroxScan {
             task: sync::Mutex::new(None), // tokio mutex
             status: Mutex::new(ScanStatus::default()),
             num_requests: 0,
+            requests_made_so_far: 0,
             scan_order: ScanOrder::Latest,
             url: String::new(),
             normalized_url: String::new(),
@@ -122,6 +129,11 @@ impl FeroxScan {
         &self.url
     }
 
+    /// getter for number of requests made during previously saved scans (i.e. --resume-from used)
+    pub fn requests_made_so_far(&self) -> u64 {
+        self.requests_made_so_far
+    }
+
     /// small wrapper to set the JoinHandle
     pub async fn set_task(&self, task: JoinHandle<()>) -> Result<()> {
         let mut guard = self.task.lock().await;
@@ -161,6 +173,8 @@ impl FeroxScan {
 
                     let pb = add_bar(&self.url, self.num_requests, bar_type);
                     pb.reset_elapsed();
+
+                    pb.set_position(self.requests_made_so_far);
 
                     let _ = std::mem::replace(&mut *guard, Some(pb.clone()));
 
@@ -368,7 +382,6 @@ impl<'de> Deserialize<'de> for FeroxScan {
         D: Deserializer<'de>,
     {
         let mut scan = Self::default();
-        let mut progress_bar_position = 0;
 
         let map: HashMap<String, Value> = HashMap::deserialize(deserializer)?;
 
@@ -416,14 +429,12 @@ impl<'de> Deserialize<'de> for FeroxScan {
                 }
                 "requests_made_so_far" => {
                     if let Some(requests_made_so_far) = value.as_u64() {
-                        progress_bar_position = requests_made_so_far;
+                        scan.requests_made_so_far = requests_made_so_far;
                     }
                 }
                 _ => {}
             }
         }
-
-        scan.progress_bar().set_position(progress_bar_position);
 
         Ok(scan)
     }
@@ -513,6 +524,7 @@ mod tests {
             scan_type: ScanType::Directory,
             scan_order: ScanOrder::Initial,
             num_requests: 0,
+            requests_made_so_far: 0,
             status: Mutex::new(ScanStatus::Running),
             task: Default::default(),
             progress_bar: Mutex::new(None),

--- a/src/scan_manager/tests.rs
+++ b/src/scan_manager/tests.rs
@@ -247,21 +247,12 @@ fn ferox_scan_deserialize() {
     }
 
     match fs.progress_bar.lock() {
-        Ok(guard) => {
-            match guard.as_ref() {
-                Some(pb) => {
-                    // position based on the requests made so far
-                    //
-                    // note: when this goes through the actual deserialize function, the
-                    // progress bar will be set to the total requests made so far, -10%
-                    // (i.e. 450 in this case)
-                    assert_eq!(pb.position(), 500);
-                }
-                None => {
-                    panic!();
-                }
+        Ok(guard) => match guard.as_ref() {
+            Some(_) => {
+                panic!();
             }
-        }
+            None => {}
+        },
         Err(_) => {
             panic!();
         }
@@ -573,6 +564,7 @@ fn feroxscan_display() {
         scan_order: ScanOrder::Latest,
         scan_type: Default::default(),
         num_requests: 0,
+        requests_made_so_far: 0,
         start_time: Instant::now(),
         output_level: OutputLevel::Default,
         status_403s: Default::default(),
@@ -618,6 +610,7 @@ async fn ferox_scan_abort() {
         scan_order: ScanOrder::Latest,
         scan_type: Default::default(),
         num_requests: 0,
+        requests_made_so_far: 0,
         start_time: Instant::now(),
         output_level: OutputLevel::Default,
         status_403s: Default::default(),

--- a/src/scan_manager/tests.rs
+++ b/src/scan_manager/tests.rs
@@ -247,12 +247,11 @@ fn ferox_scan_deserialize() {
     }
 
     match fs.progress_bar.lock() {
-        Ok(guard) => match guard.as_ref() {
-            Some(_) => {
+        Ok(guard) => {
+            if guard.is_some() {
                 panic!();
             }
-            None => {}
-        },
+        }
         Err(_) => {
             panic!();
         }

--- a/tests/test_scan_manager.rs
+++ b/tests/test_scan_manager.rs
@@ -20,12 +20,12 @@ fn resume_scan_works() {
     // localhost:PORT/ <- complete
     // localhost:PORT/js <- will get scanned with /css and /stuff
     let complete_scan = format!(
-        r#"{{"id":"057016a14769414aac9a7a62707598cb","url":"{}","normalized_url":"{}","scan_type":"Directory","status":"Complete"}}"#,
+        r#"{{"id":"057016a14769414aac9a7a62707598cb","url":"{}","normalized_url":"{}","scan_type":"Directory","status":"Complete","num_requests":4174,"requests_made_so_far":0}}"#,
         srv.url("/"),
         srv.url("/"),
     );
     let incomplete_scan = format!(
-        r#"{{"id":"400b2323a16f43468a04ffcbbeba34c6","url":"{}","normalized_url":"{}/","scan_type":"Directory","status":"NotStarted"}}"#,
+        r#"{{"id":"400b2323a16f43468a04ffcbbeba34c6","url":"{}","normalized_url":"{}/","scan_type":"Directory","status":"NotStarted","num_requests":4174,"requests_made_so_far":0}}"#,
         srv.url("/js"),
         srv.url("/js")
     );
@@ -64,10 +64,13 @@ fn resume_scan_works() {
     });
 
     let state_file_contents = format!("{{{scans},{config},{responses}}}");
+
     let (tmp_dir2, state_file) = setup_tmp_directory(&[state_file_contents], "state-file").unwrap();
 
     Command::cargo_bin("feroxbuster")
         .unwrap()
+        .arg("-vvv")
+        .arg("--burp")
         .arg("--resume-from")
         .arg(state_file.as_os_str())
         .assert()

--- a/tests/test_scan_manager.rs
+++ b/tests/test_scan_manager.rs
@@ -70,7 +70,6 @@ fn resume_scan_works() {
     Command::cargo_bin("feroxbuster")
         .unwrap()
         .arg("-vvv")
-        .arg("--burp")
         .arg("--resume-from")
         .arg(state_file.as_os_str())
         .assert()


### PR DESCRIPTION
closes #751 

# Landing a Pull Request (PR)

Long form explanations of most of the items below can be found in the [CONTRIBUTING](https://github.com/epi052/feroxbuster/blob/master/CONTRIBUTING.md) guide.

## Branching checklist
- [ ] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [ ] Your PR description references the associated issue (i.e. fixes #123456)
- [ ] Code is in its own branch
- [ ] Branch name is related to the PR contents
- [ ] PR targets main

## Static analysis checks
- [ ] All rust files are formatted using `cargo fmt`
- [ ] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::mutex-atomic`
- [ ] All existing tests pass

## Documentation
- [ ] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [ ] Documentation about your PR is included in the `docs`, as needed. The docs live in a [separate repository](https://epi052.github.io/feroxbuster-docs/docs/). Update the appropriate pages at the links below.
  - [ ] update [example config file section](https://epi052.github.io/feroxbuster-docs/docs/configuration/ferox-config-toml/)
  - [ ] update [help output section](https://epi052.github.io/feroxbuster-docs/docs/configuration/command-line/)
  - [ ] add an [example](https://epi052.github.io/feroxbuster-docs/docs/examples/)
  - [ ] update [comparison table](https://epi052.github.io/feroxbuster-docs/docs/compare/)

## Additional Tests
- [ ] New code is unit tested
- [ ] New code is integration tested, as needed
- [ ] New tests pass
