### PR TITLE
Showing banner again after finish scan management menu

### DIFF
--- a/src/scan_manager/scan_container.rs
+++ b/src/scan_manager/scan_container.rs
@@ -8,7 +8,8 @@ use crate::filters::{
 use crate::traits::FeroxFilter;
 use crate::Command::AddFilter;
 use crate::{
-    config::OutputLevel,
+    banner::Banner,
+    config::{Configuration, OutputLevel},
     progress::PROGRESS_PRINTER,
     progress::{add_bar, BarType},
     scan_manager::{MenuCmd, MenuCmdResult},
@@ -24,7 +25,7 @@ use std::{
     collections::HashSet,
     convert::TryInto,
     fs::File,
-    io::BufReader,
+    io::{BufReader, stderr},
     ops::Index,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -446,6 +447,12 @@ impl FeroxScans {
         };
 
         self.menu.clear_screen();
+        
+        let config = Configuration::new().unwrap();
+        let target = &config.target_url;
+        let banner = Banner::new(&[String::from(target)], &config);
+        banner.print_to(stderr(), Arc::new(config)).unwrap(); 
+
         self.menu.show_progress_bars();
 
         result

--- a/src/scan_manager/scan_container.rs
+++ b/src/scan_manager/scan_container.rs
@@ -9,7 +9,7 @@ use crate::traits::FeroxFilter;
 use crate::Command::AddFilter;
 use crate::{
     banner::Banner,
-    config::{Configuration, OutputLevel},
+    config::OutputLevel,
     progress::PROGRESS_PRINTER,
     progress::{add_bar, BarType},
     scan_manager::{MenuCmd, MenuCmdResult},
@@ -25,7 +25,7 @@ use std::{
     collections::HashSet,
     convert::TryInto,
     fs::File,
-    io::{stderr, BufReader},
+    io::BufReader,
     ops::Index,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -448,10 +448,10 @@ impl FeroxScans {
 
         self.menu.clear_screen();
 
-        let config = Configuration::new().unwrap();
-        let target = &config.target_url;
-        let banner = Banner::new(&[String::from(target)], &config);
-        banner.print_to(stderr(), Arc::new(config)).unwrap();
+        let banner = Banner::new(&[handles.config.target_url.clone()], &handles.config);
+        banner
+            .print_to(&self.menu.term, handles.config.clone())
+            .unwrap_or_default();
 
         self.menu.show_progress_bars();
 

--- a/src/scan_manager/scan_container.rs
+++ b/src/scan_manager/scan_container.rs
@@ -25,7 +25,7 @@ use std::{
     collections::HashSet,
     convert::TryInto,
     fs::File,
-    io::{BufReader, stderr},
+    io::{stderr, BufReader},
     ops::Index,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -447,11 +447,11 @@ impl FeroxScans {
         };
 
         self.menu.clear_screen();
-        
+
         let config = Configuration::new().unwrap();
         let target = &config.target_url;
         let banner = Banner::new(&[String::from(target)], &config);
-        banner.print_to(stderr(), Arc::new(config)).unwrap(); 
+        banner.print_to(stderr(), Arc::new(config)).unwrap();
 
         self.menu.show_progress_bars();
 


### PR DESCRIPTION
Fixes #805 

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123456)
- [x] Code is in its own branch
- [x] Branch name is related to the PR contents
- [ ] PR targets main

## Static analysis checks
- [x] All rust files are formatted using `cargo fmt`
- [x] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::mutex-atomic`
- [x] All existing tests pass

## Documentation
- [ ] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [ ] Documentation about your PR is included in the `docs`, as needed. The docs live in a [separate repository](https://epi052.github.io/feroxbuster-docs/docs/). Update the appropriate pages at the links below.
  - [ ] update [example config file section](https://epi052.github.io/feroxbuster-docs/docs/configuration/ferox-config-toml/)
  - [ ] update [help output section](https://epi052.github.io/feroxbuster-docs/docs/configuration/command-line/)
  - [ ] add an [example](https://epi052.github.io/feroxbuster-docs/docs/examples/)
  - [ ] update [comparison table](https://epi052.github.io/feroxbuster-docs/docs/compare/)

## Additional Tests
- [ ] New code is unit tested
- [ ] New code is integration tested, as needed
- [ ] New tests pass
