### PR TITLE
[WIP][Enhancement] Add Parsing for `sitemap.xml`

### DIFF
--- a/src/extractor/builder.rs
+++ b/src/extractor/builder.rs
@@ -29,6 +29,9 @@ pub enum ExtractionTarget {
 
     /// Extract all <a> tags from a page
     DirectoryListing,
+
+    /// Examine sitemap.xml (specifically) and extract links
+    SitemapXml,
 }
 
 /// responsible for building an `Extractor`

--- a/src/scanner/ferox_scanner.rs
+++ b/src/scanner/ferox_scanner.rs
@@ -217,6 +217,18 @@ impl FeroxScanner {
 
             let result = extractor.extract().await?;
             extraction_tasks.push(extractor.request_links(result).await?)
+
+
+            // check for sitemap.xml (assuming it also cannot be in sub-directories, so limited to Initial)
+            let mut sitemap_extractor = ExtractorBuilder::default()
+            .target(ExtractionTarget::SitemapXml)  // Use the SitemapXml variant here
+            .url(&self.target_url)
+            .handles(self.handles.clone())
+            .build()?;
+
+            let sitemap_result = sitemap_extractor.extract().await?;
+            extraction_tasks.push(sitemap_extractor.request_links(sitemap_result).await?);
+
         }
 
         let scanned_urls = self.handles.ferox_scans()?;


### PR DESCRIPTION
Hi,

Building upon the discussion in the [issue](https://github.com/epi052/feroxbuster/issues/997) I opened earlier, I believe adding the capability to parse the `sitemap.xml` file could significantly benefit the tool, especially when the file is present on a target website.

This is my first foray into Rust development, so I've provided this initial code as a starting point.

I have note created appropriated methods inside the test module either.

Hope it could help.