### PR TITLE
allow --json in conjunction with --silent

### DIFF
--- a/shell_completions/_feroxbuster
+++ b/shell_completions/_feroxbuster
@@ -103,7 +103,7 @@ _feroxbuster() {
 '--collect-words[Automatically discover important words from within responses and add them to the wordlist]' \
 '(--silent)*-v[Increase verbosity level (use -vv or more for greater effect. \[CAUTION\] 4 -v'\''s is probably too much)]' \
 '(--silent)*--verbosity[Increase verbosity level (use -vv or more for greater effect. \[CAUTION\] 4 -v'\''s is probably too much)]' \
-'(-q --quiet)--silent[Only print URLs + turn off logging (good for piping a list of urls to other commands)]' \
+'(-q --quiet)--silent[Only print URLs (or JSON w/ --json) + turn off logging (good for piping a list of urls to other commands)]' \
 '-q[Hide progress bars and banner (good for tmux windows w/ notifications)]' \
 '--quiet[Hide progress bars and banner (good for tmux windows w/ notifications)]' \
 '--json[Emit JSON logs to --output and --debug-log instead of normal text]' \

--- a/shell_completions/_feroxbuster.ps1
+++ b/shell_completions/_feroxbuster.ps1
@@ -109,7 +109,7 @@ Register-ArgumentCompleter -Native -CommandName 'feroxbuster' -ScriptBlock {
             [CompletionResult]::new('--collect-words', 'collect-words', [CompletionResultType]::ParameterName, 'Automatically discover important words from within responses and add them to the wordlist')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Increase verbosity level (use -vv or more for greater effect. [CAUTION] 4 -v''s is probably too much)')
             [CompletionResult]::new('--verbosity', 'verbosity', [CompletionResultType]::ParameterName, 'Increase verbosity level (use -vv or more for greater effect. [CAUTION] 4 -v''s is probably too much)')
-            [CompletionResult]::new('--silent', 'silent', [CompletionResultType]::ParameterName, 'Only print URLs + turn off logging (good for piping a list of urls to other commands)')
+            [CompletionResult]::new('--silent', 'silent', [CompletionResultType]::ParameterName, 'Only print URLs (or JSON w/ --json) + turn off logging (good for piping a list of urls to other commands)')
             [CompletionResult]::new('-q', 'q', [CompletionResultType]::ParameterName, 'Hide progress bars and banner (good for tmux windows w/ notifications)')
             [CompletionResult]::new('--quiet', 'quiet', [CompletionResultType]::ParameterName, 'Hide progress bars and banner (good for tmux windows w/ notifications)')
             [CompletionResult]::new('--json', 'json', [CompletionResultType]::ParameterName, 'Emit JSON logs to --output and --debug-log instead of normal text')

--- a/shell_completions/feroxbuster.elv
+++ b/shell_completions/feroxbuster.elv
@@ -106,7 +106,7 @@ set edit:completion:arg-completer[feroxbuster] = {|@words|
             cand --collect-words 'Automatically discover important words from within responses and add them to the wordlist'
             cand -v 'Increase verbosity level (use -vv or more for greater effect. [CAUTION] 4 -v''s is probably too much)'
             cand --verbosity 'Increase verbosity level (use -vv or more for greater effect. [CAUTION] 4 -v''s is probably too much)'
-            cand --silent 'Only print URLs + turn off logging (good for piping a list of urls to other commands)'
+            cand --silent 'Only print URLs (or JSON w/ --json) + turn off logging (good for piping a list of urls to other commands)'
             cand -q 'Hide progress bars and banner (good for tmux windows w/ notifications)'
             cand --quiet 'Hide progress bars and banner (good for tmux windows w/ notifications)'
             cand --json 'Emit JSON logs to --output and --debug-log instead of normal text'

--- a/src/config/container.rs
+++ b/src/config/container.rs
@@ -794,7 +794,11 @@ impl Configuration {
             // if the line below is outside of the if, we'd overwrite true with
             // false if no --silent is used on the command line
             config.silent = true;
-            config.output_level = OutputLevel::Silent;
+            config.output_level = if config.json {
+                OutputLevel::SilentJSON
+            } else {
+                OutputLevel::Silent
+            };
         }
 
         if came_from_cli!(args, "quiet") {
@@ -1061,6 +1065,7 @@ impl Configuration {
             new.server_certs,
             Vec::<String>::new()
         );
+        update_if_not_default!(&mut conf.json, new.json, false);
         update_if_not_default!(&mut conf.client_cert, new.client_cert, "");
         update_if_not_default!(&mut conf.client_key, new.client_key, "");
         update_if_not_default!(&mut conf.verbosity, new.verbosity, 0);
@@ -1072,7 +1077,7 @@ impl Configuration {
         update_if_not_default!(&mut conf.collect_backups, new.collect_backups, false);
         update_if_not_default!(&mut conf.collect_words, new.collect_words, false);
         // use updated quiet/silent values to determine output level; same for requester policy
-        conf.output_level = determine_output_level(conf.quiet, conf.silent);
+        conf.output_level = determine_output_level(conf.quiet, conf.silent, conf.json);
         conf.requester_policy = determine_requester_policy(conf.auto_tune, conf.auto_bail);
         update_if_not_default!(&mut conf.output, new.output, "");
         update_if_not_default!(&mut conf.redirects, new.redirects, false);
@@ -1130,7 +1135,6 @@ impl Configuration {
         update_if_not_default!(&mut conf.replay_proxy, new.replay_proxy, "");
         update_if_not_default!(&mut conf.debug_log, new.debug_log, "");
         update_if_not_default!(&mut conf.resume_from, new.resume_from, "");
-        update_if_not_default!(&mut conf.json, new.json, false);
 
         update_if_not_default!(&mut conf.timeout, new.timeout, timeout());
         update_if_not_default!(&mut conf.user_agent, new.user_agent, user_agent());

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -100,6 +100,9 @@ pub enum OutputLevel {
 
     /// silent scan, only print urls (used to be --quiet in versions 1.x.x)
     Silent,
+
+    /// silent scan, but with JSON output
+    SilentJSON,
 }
 
 /// implement a default for OutputLevel
@@ -111,14 +114,22 @@ impl Default for OutputLevel {
 }
 
 /// given the current settings for quiet and silent, determine output_level (DRY helper)
-pub fn determine_output_level(quiet: bool, silent: bool) -> OutputLevel {
+pub fn determine_output_level(quiet: bool, silent: bool, json: bool) -> OutputLevel {
     if quiet && silent {
         // user COULD have both as true in config file, take the more quiet of the two
-        OutputLevel::Silent
+        if json {
+            OutputLevel::SilentJSON
+        } else {
+            OutputLevel::Silent
+        }
     } else if quiet {
         OutputLevel::Quiet
     } else if silent {
-        OutputLevel::Silent
+        if json {
+            OutputLevel::SilentJSON
+        } else {
+            OutputLevel::Silent
+        }
     } else {
         OutputLevel::Default
     }
@@ -166,16 +177,28 @@ mod tests {
     #[test]
     /// test determine_output_level returns higher of the two levels if both given values are true
     fn determine_output_level_returns_correct_results() {
-        let mut level = determine_output_level(true, true);
+        let mut level = determine_output_level(true, true, false);
         assert_eq!(level, OutputLevel::Silent);
 
-        level = determine_output_level(false, true);
+        level = determine_output_level(false, true, false);
         assert_eq!(level, OutputLevel::Silent);
 
-        level = determine_output_level(false, false);
+        let mut level = determine_output_level(true, true, true);
+        assert_eq!(level, OutputLevel::SilentJSON);
+
+        level = determine_output_level(false, true, true);
+        assert_eq!(level, OutputLevel::SilentJSON);
+
+        level = determine_output_level(false, false, false);
         assert_eq!(level, OutputLevel::Default);
 
-        level = determine_output_level(true, false);
+        level = determine_output_level(true, false, false);
+        assert_eq!(level, OutputLevel::Quiet);
+
+        level = determine_output_level(false, false, true);
+        assert_eq!(level, OutputLevel::Default);
+
+        level = determine_output_level(true, false, true);
         assert_eq!(level, OutputLevel::Quiet);
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -594,7 +594,7 @@ pub fn initialize() -> Command {
                 .num_args(0)
                 .conflicts_with("quiet")
                 .help_heading("Output settings")
-                .help("Only print URLs + turn off logging (good for piping a list of urls to other commands)")
+                .help("Only print URLs (or JSON w/ --json) + turn off logging (good for piping a list of urls to other commands)")
         )
         .arg(
             Arg::new("quiet")
@@ -645,7 +645,7 @@ pub fn initialize() -> Command {
     let mut app = app
         .group(
             ArgGroup::new("output_files")
-                .args(["debug_log", "output"])
+                .args(["debug_log", "output", "silent"])
                 .multiple(true),
         )
         .arg(

--- a/src/response.rs
+++ b/src/response.rs
@@ -485,15 +485,19 @@ impl FeroxSerialize for FeroxResponse {
             message
         } else {
             // not a wildcard, just create a normal entry
-            utils::create_report_string(
-                self.status.as_str(),
-                method,
-                &lines,
-                &words,
-                &chars,
-                &url_with_redirect,
-                self.output_level,
-            )
+            if matches!(self.output_level, OutputLevel::SilentJSON) {
+                self.as_json().unwrap_or_default()
+            } else {
+                utils::create_report_string(
+                    self.status.as_str(),
+                    method,
+                    &lines,
+                    &words,
+                    &chars,
+                    &url_with_redirect,
+                    self.output_level,
+                )
+            }
         }
     }
 

--- a/src/scan_manager/scan.rs
+++ b/src/scan_manager/scan.rs
@@ -175,7 +175,7 @@ impl FeroxScan {
                     let bar_type = match self.output_level {
                         OutputLevel::Default => BarType::Default,
                         OutputLevel::Quiet => BarType::Quiet,
-                        OutputLevel::Silent => BarType::Hidden,
+                        OutputLevel::Silent | OutputLevel::SilentJSON => BarType::Hidden,
                     };
 
                     let pb = add_bar(&self.url, self.num_requests, bar_type);
@@ -194,7 +194,7 @@ impl FeroxScan {
                 let bar_type = match self.output_level {
                     OutputLevel::Default => BarType::Default,
                     OutputLevel::Quiet => BarType::Quiet,
-                    OutputLevel::Silent => BarType::Hidden,
+                    OutputLevel::Silent | OutputLevel::SilentJSON => BarType::Hidden,
                 };
 
                 let pb = add_bar(&self.url, self.num_requests, bar_type);

--- a/src/scan_manager/scan_container.rs
+++ b/src/scan_manager/scan_container.rs
@@ -516,7 +516,7 @@ impl FeroxScans {
         let bar_type = match self.output_level {
             OutputLevel::Default => BarType::Message,
             OutputLevel::Quiet => BarType::Quiet,
-            OutputLevel::Silent => return Ok(()), // fast exit when --silent was used
+            OutputLevel::Silent | OutputLevel::SilentJSON => return Ok(()), // fast exit when --silent was used
         };
 
         if let Ok(scans) = self.scans.read() {
@@ -609,7 +609,7 @@ impl FeroxScans {
                 let bar_type = match self.output_level {
                     OutputLevel::Default => BarType::Default,
                     OutputLevel::Quiet => BarType::Quiet,
-                    OutputLevel::Silent => BarType::Hidden,
+                    OutputLevel::Silent | OutputLevel::SilentJSON => BarType::Hidden,
                 };
 
                 let progress_bar = add_bar(url, bar_length, bar_type);


### PR DESCRIPTION
closes #1002 
# Landing a Pull Request (PR)

Long form explanations of most of the items below can be found in the [CONTRIBUTING](https://github.com/epi052/feroxbuster/blob/master/CONTRIBUTING.md) guide.

## Branching checklist
- [ ] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [ ] Your PR description references the associated issue (i.e. fixes #123456)
- [ ] Code is in its own branch
- [ ] Branch name is related to the PR contents
- [ ] PR targets main

## Static analysis checks
- [ ] All rust files are formatted using `cargo fmt`
- [ ] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::mutex-atomic`
- [ ] All existing tests pass

## Documentation
- [ ] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [ ] Documentation about your PR is included in the `docs`, as needed. The docs live in a [separate repository](https://epi052.github.io/feroxbuster-docs/docs/). Update the appropriate pages at the links below.
  - [ ] update [example config file section](https://epi052.github.io/feroxbuster-docs/docs/configuration/ferox-config-toml/)
  - [ ] update [help output section](https://epi052.github.io/feroxbuster-docs/docs/configuration/command-line/)
  - [ ] add an [example](https://epi052.github.io/feroxbuster-docs/docs/examples/)
  - [ ] update [comparison table](https://epi052.github.io/feroxbuster-docs/docs/compare/)

## Additional Tests
- [ ] New code is unit tested
- [ ] New code is integration tested, as needed
- [ ] New tests pass
