### PR TITLE
query fontconfig to determine if Noto Color Emoji is installed

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -44,7 +44,7 @@ elif [[ "$(expr substr $(uname -s) 1 5)" == "Linux" ]]; then
     rm "$LIN64_ZIP"
   fi
 
-  if [[ -e ~/.fonts/NotoColorEmoji.ttf ]]; then
+  if [[ "$(fc-list NotoColorEmoji | wc -l)" -gt 0 ]]; then
     echo "[=] Found Noto Emoji Font, skipping install"
   else
     echo "[=] Installing Noto Emoji Font"


### PR DESCRIPTION
Fontconfig allows fonts to be installed in many places.

This PR queries fontconfig to see if it knows about a Noto Color Emoji font to decide whether to install the font instead of just checking ~/.fonts.

I didn't create an issue because this is literally a one line change and the PR is self explanatory imo.