### PR TITLE
Fix `workflow_dispatch` trigger for Winget workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -3,6 +3,11 @@ on:
   release:
     types: [released]
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name of release'
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -13,4 +18,4 @@ jobs:
           identifier: epi052.feroxbuster
           installers-regex: '-windows-feroxbuster\.exe\.zip$'
           token: ${{ secrets.WINGET_TOKEN }}
-          version: "2.10.4"
+          release-tag: ${{ inputs.tag_name || github.event.release.tag_name || github.ref_name }}


### PR DESCRIPTION
# Landing a Pull Request (PR)

I'm not sure why the `release` trigger did not trigger, but anyhow, I added a tag name input to the `workflow_dispatch` trigger to fix the workflow failure.

## Branching checklist
- [ ] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [ ] Your PR description references the associated issue (i.e. fixes #123456)
- [ ] Code is in its own branch
- [ ] Branch name is related to the PR contents
- [ ] PR targets main

## Static analysis checks
- [ ] All rust files are formatted using `cargo fmt`
- [ ] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::mutex-atomic`
- [ ] All existing tests pass

## Documentation
- [ ] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [ ] Documentation about your PR is included in the `docs`, as needed. The docs live in a [separate repository](https://epi052.github.io/feroxbuster-docs/docs/). Update the appropriate pages at the links below.
  - [ ] update [example config file section](https://epi052.github.io/feroxbuster-docs/docs/configuration/ferox-config-toml/)
  - [ ] update [help output section](https://epi052.github.io/feroxbuster-docs/docs/configuration/command-line/)
  - [ ] add an [example](https://epi052.github.io/feroxbuster-docs/docs/examples/)
  - [ ] update [comparison table](https://epi052.github.io/feroxbuster-docs/docs/compare/)

## Additional Tests
- [ ] New code is unit tested
- [ ] New code is integration tested, as needed
- [ ] New tests pass
