### PR TITLE
docs: replace -Zprofile with instrument-coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ lcov_cobertura.py
 
 # state file created during tests
 ferox-*.state
+feroxbuster-*.profraw
 
 # python stuff cuz reasons
 Pipfile*

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ lcov_cobertura.py
 
 # state file created during tests
 ferox-*.state
-feroxbuster-*.profraw
 
 # python stuff cuz reasons
 Pipfile*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,14 +182,16 @@ Test coverage can be checked using [grcov](https://github.com/mozilla/grcov).  I
 
 ```sh
 cargo install grcov
+rustup component add llvm-tools
 rustup install nightly
 rustup default nightly
 export CARGO_INCREMENTAL=0
-export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+export RUSTFLAGS="-Cinstrument-coverage"
+export LLVM_PROFILE_FILE="feroxbuster-%p-%m.profraw"
 export RUSTDOCFLAGS="-Cpanic=abort"
 cargo build
 cargo test
-grcov ./target/debug/ -s . -t html --llvm --branch --ignore-not-existing -o ./target/debug/coverage/
+grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/coverage/
 firefox target/debug/coverage/index.html
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,12 +186,13 @@ rustup component add llvm-tools
 rustup install nightly
 rustup default nightly
 export CARGO_INCREMENTAL=0
-export RUSTFLAGS="-Cinstrument-coverage"
-export LLVM_PROFILE_FILE="feroxbuster-%p-%m.profraw"
+export RUSTFLAGS="-Cinstrument-coverage -Clink-dead-code -Ccodegen-units=1 -Coverflow-checks=off"
+export LLVM_PROFILE_FILE="target/debug/coverage/profraw/feroxbuster-%p-%m.profraw"
 export RUSTDOCFLAGS="-Cpanic=abort"
+rm -r target/debug/coverage/profraw
 cargo build
 cargo test
-grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/coverage/
+grcov . --source-dir . --keep-only "src/*" --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/coverage/
 firefox target/debug/coverage/index.html
 ```
 


### PR DESCRIPTION
# Landing a Pull Request (PR)

Fixes #1244

Long form explanations of most of the items below can be found in the [CONTRIBUTING](https://github.com/epi052/feroxbuster/blob/master/CONTRIBUTING.md) guide.

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123456)
- [x] Code is in its own branch
- [x] Branch name is related to the PR contents
- [x] PR targets main

## Static analysis checks
- [x] All rust files are formatted using `cargo fmt`
- [ ] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::mutex-atomic`
- [ ] All existing tests pass

## Documentation
- [ ] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [ ] Documentation about your PR is included in the `docs`, as needed. The docs live in a [separate repository](https://epi052.github.io/feroxbuster-docs/docs/). Update the appropriate pages at the links below.
  - [ ] update [example config file section](https://epi052.github.io/feroxbuster-docs/docs/configuration/ferox-config-toml/)
  - [ ] update [help output section](https://epi052.github.io/feroxbuster-docs/docs/configuration/command-line/)
  - [ ] add an [example](https://epi052.github.io/feroxbuster-docs/docs/examples/)

## Additional Tests
- [ ] New code is unit tested
- [ ] New code is integration tested, as needed
- [ ] New tests pass
