### PR TITLE
Added one more entry in ignored extensions list

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,10 +54,11 @@ pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_OPEN_FILE_LIMIT: u64 = 8192;
 
 /// Default set of extensions to Ignore when auto-collecting extensions during scans
-pub(crate) const DEFAULT_IGNORED_EXTENSIONS: [&str; 38] = [
-    "tif", "tiff", "ico", "cur", "bmp", "webp", "svg", "png", "jpg", "jpeg", "jfif", "gif", "avif",
-    "apng", "pjpeg", "pjp", "mov", "wav", "mpg", "mpeg", "mp3", "mp4", "m4a", "m4p", "m4v", "ogg",
-    "webm", "ogv", "oga", "flac", "aac", "3gp", "css", "zip", "xls", "xml", "gz", "tgz",
+pub(crate) const DEFAULT_IGNORED_EXTENSIONS: [&str; 43] = [
+    "woff2", "woff", "ttf", "otf", "eot", "tif", "tiff", "ico", "cur", "bmp", "webp", "svg", "png",
+    "jpg", "jpeg", "jfif", "gif", "avif", "apng", "pjpeg", "pjp", "mov", "wav", "mpg", "mpeg",
+    "mp3", "mp4", "m4a", "m4p", "m4v", "ogg", "webm", "ogv", "oga", "flac", "aac", "3gp", "css",
+    "zip", "xls", "xml", "gz", "tgz",
 ];
 
 /// Default set of extensions to search for when auto-collecting backups during scans

--- a/src/scan_manager/tests.rs
+++ b/src/scan_manager/tests.rs
@@ -555,7 +555,7 @@ fn feroxstates_feroxserialize_implementation() {
         r#""response_size_limit":4194304"#,
         r#""filters":[{"filter_code":100},{"word_count":200},{"content_length":300},{"line_count":400},{"compiled":".*","raw_string":".*"},{"hash":1,"original_url":"http://localhost:12345/","cutoff":3}]"#,
         r#""collected_extensions":["php"]"#,
-        r#""dont_collect":["tif","tiff","ico","cur","bmp","webp","svg","png","jpg","jpeg","jfif","gif","avif","apng","pjpeg","pjp","mov","wav","mpg","mpeg","mp3","mp4","m4a","m4p","m4v","ogg","webm","ogv","oga","flac","aac","3gp","css","zip","xls","xml","gz","tgz"]"#,
+        r#""dont_collect":["woff2","woff","ttf","otf","eot","tif","tiff","ico","cur","bmp","webp","svg","png","jpg","jpeg","jfif","gif","avif","apng","pjpeg","pjp","mov","wav","mpg","mpeg","mp3","mp4","m4a","m4p","m4v","ogg","webm","ogv","oga","flac","aac","3gp","css","zip","xls","xml","gz","tgz"]"#,
     ]
     .iter()
     {


### PR DESCRIPTION
I added one more entry `woff2` in extensions that are ignored by `--collect-extensions` flag. `woff2` is just a font file and is usually present in web applications but not interesting at all like `.css`, `.png` and other files.