### PR TITLE
Improve the robots.txt regex

### DIFF
--- a/src/extractor/builder.rs
+++ b/src/extractor/builder.rs
@@ -51,7 +51,7 @@ pub(super) const LINKFINDER_REGEX: &str = r#"(?x)
 ///
 /// ref: https://developers.google.com/search/reference/robots_txt
 pub(super) const ROBOTS_TXT_REGEX: &str =
-    r#"(?m)^ *(Allow|Disallow): *(?P<url_path>[a-zA-Z0-9._/?#@!&'()+,;%=-]+?)$"#; // multi-line (?m)
+    r#"(?m)^[ \t]*(?i)(allow|disallow)[ \t]*:[ \t]*(?P<url_path>[^ \t\r\n#$]*)?[ \t]*\$?(?:#.*)?$"#; // multi-line (?m), case-insensitive (?i)
 
 /// Regular expression to filter bad characters from extracted url paths
 ///


### PR DESCRIPTION
This pull request fixes the bug from issue #1289.

The old regex missed some endpoints:

![regex_old](https://github.com/user-attachments/assets/57f14cda-c3f9-4c0a-ba8d-e30d662c95fc)

The new regex:
- uses case-insensitive matching for the "allow" and "disallow" rules,
- supports the white-space characters from the RFC <https://datatracker.ietf.org/doc/html/rfc9309#name-formal-syntax>,
- supports more characters in the URL and
- supports the `#` and the `$` special characters <https://datatracker.ietf.org/doc/html/rfc9309#name-special-characters>.

![regex_new](https://github.com/user-attachments/assets/65372f6b-5a28-4055-9aa7-e477340e64ec)

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123456)
- [x] Code is in its own branch
- [x] Branch name is related to the PR contents
- [x] PR targets main

## Static analysis checks
- [x] All rust files are formatted using `cargo fmt`
- [x] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::mutex-atomic`
- [x] All existing tests pass

## Documentation
- [ ] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [ ] Documentation about your PR is included in the `docs`, as needed. The docs live in a [separate repository](https://epi052.github.io/feroxbuster-docs/). Update the appropriate pages at the links below.
  - [ ] update [example config file section](https://epi052.github.io/feroxbuster-docs/configuration/ferox-config-toml/)
  - [ ] update [help output section](https://epi052.github.io/feroxbuster-docs/configuration/command-line/)
  - [ ] add an [example](https://epi052.github.io/feroxbuster-docs/examples/auto-tune/)

## Additional Tests
- [ ] New code is unit tested
- [ ] New code is integration tested, as needed
- [ ] New tests pass
