### PR TITLE
fix: support LF-only line endings in --request-file parsing

### DIFF
--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -389,8 +389,11 @@ pub fn parse_request_file(config: &mut Configuration) -> Result<()> {
         bail!("Empty --request-file file provided");
     }
 
+    // normalize the body to support both CRLF
+    // and LF-only inputs (common when copy-pasting)
+    let normalized = contents.replace("\r\n", "\n");
     // this should split the body from the request line and headers
-    let lines = contents.split("\r\n\r\n").collect::<Vec<&str>>();
+    let lines = normalized.splitn(2, "\n\n").collect::<Vec<&str>>();
 
     if lines.len() < 2 {
         bail!("Invalid request: Missing head/body CRLF separator");
@@ -406,7 +409,7 @@ pub fn parse_request_file(config: &mut Configuration) -> Result<()> {
     }
 
     // begin parsing the request line and headers
-    let mut head_parts = head.split("\r\n");
+    let mut head_parts = head.split("\n");
 
     let Some(request_line) = head_parts.next() else {
         bail!("Invalid request: Missing request line");
@@ -441,7 +444,7 @@ pub fn parse_request_file(config: &mut Configuration) -> Result<()> {
     }
 
     for mut line in head_parts {
-        line = line.trim();
+        line = line.trim_matches('\r').trim();
 
         if line.is_empty() {
             break; // Empty line signals the end of headers

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -403,7 +403,7 @@ pub fn parse_request_file(config: &mut Configuration) -> Result<()> {
     let head_bytes = &contents[..sep_idx];
     let body_bytes = &contents[sep_idx + sep_len..];
 
-    // decode only the head; HTTP framing is generally ascii/utf-8 
+    // decode only the head; HTTP framing is generally ascii/utf-8
     // compatible
     let head = std::str::from_utf8(head_bytes)
         .map_err(|_| anyhow::anyhow!("Request headers contain invalid UTF-8"))?;
@@ -1362,9 +1362,8 @@ mod tests {
     fn test_parse_raw_lf_only_request() -> io::Result<()> {
         let mut tmp = TempSetup::new();
 
-        tmp.file.write_all(
-            b"GET / HTTP/1.1\nHost: example.com\n\nbody"
-        )?;
+        tmp.file
+            .write_all(b"GET / HTTP/1.1\nHost: example.com\n\nbody")?;
 
         let result = parse_request_file(&mut tmp.config);
 
@@ -1379,9 +1378,8 @@ mod tests {
     fn test_parse_raw_crlf_request() -> io::Result<()> {
         let mut tmp = TempSetup::new();
 
-        tmp.file.write_all(
-            b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\nbody"
-        )?;
+        tmp.file
+            .write_all(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\nbody")?;
 
         let result = parse_request_file(&mut tmp.config);
 
@@ -1434,9 +1432,8 @@ mod tests {
     fn test_parse_raw_mixed_newlines_headers() -> io::Result<()> {
         let mut tmp = TempSetup::new();
 
-        tmp.file.write_all(
-            b"GET / HTTP/1.1\r\nHost: example.com\nUser-Agent: test\r\n\nbody"
-        )?;
+        tmp.file
+            .write_all(b"GET / HTTP/1.1\r\nHost: example.com\nUser-Agent: test\r\n\nbody")?;
 
         let result = parse_request_file(&mut tmp.config);
 

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -1449,4 +1449,23 @@ mod tests {
         tmp.cleanup();
         Ok(())
     }
+
+    #[test]
+    fn test_parse_raw_binary_body_preserved() -> io::Result<()> {
+        let mut tmp = TempSetup::new();
+
+        let body = b"\x00\xde\xad\xbe\xef\x80binary";
+
+        let mut request = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n".to_vec();
+        request.extend_from_slice(body);
+
+        tmp.file.write_all(&request)?;
+
+        parse_request_file(&mut tmp.config).unwrap();
+
+        assert_eq!(tmp.config.data, body.to_vec());
+
+        tmp.cleanup();
+        Ok(())
+    }
 }

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -390,13 +390,23 @@ pub fn parse_request_file(config: &mut Configuration) -> Result<()> {
     }
 
     // find the first header/body separator
-    // prefer \r\n\r\n, otherwise accept \n\n
-    let (sep_idx, sep_len) = if let Some(idx) = contents.windows(4).position(|w| w == b"\r\n\r\n") {
-        (idx, 4)
-    } else if let Some(idx) = contents.windows(2).position(|w| w == b"\n\n") {
-        (idx, 2)
-    } else {
-        bail!("Invalid request: Missing head/body separator")
+    // locate both \r\n\r\n and \n\n and pick whichever appears earliest,
+    // so that a \r\n\r\n inside the body doesn't shadow a \n\n separator
+    // that terminates the headers
+    let crlf = contents.windows(4).position(|w| w == b"\r\n\r\n");
+    let lf = contents.windows(2).position(|w| w == b"\n\n");
+
+    let (sep_idx, sep_len) = match (crlf, lf) {
+        (Some(c), Some(l)) => {
+            if c <= l {
+                (c, 4)
+            } else {
+                (l, 2)
+            }
+        }
+        (Some(c), None) => (c, 4),
+        (None, Some(l)) => (l, 2),
+        (None, None) => bail!("Invalid request: Missing head/body separator"),
     };
 
     // split the request head and body
@@ -1461,6 +1471,39 @@ mod tests {
         parse_request_file(&mut tmp.config).unwrap();
 
         assert_eq!(tmp.config.data, body.to_vec());
+
+        tmp.cleanup();
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_raw_lf_headers_with_crlf_crlf_in_body() -> io::Result<()> {
+        // headers are LF-separated; body contains \r\n\r\n
+        let mut tmp = TempSetup::new();
+
+        tmp.file.write_all(
+            b"POST /upload HTTP/1.1\nHost: example.com\nContent-Type: application/octet-stream\n\nabc\r\n\r\ndef",
+        )?;
+
+        let result = parse_request_file(&mut tmp.config);
+
+        assert!(result.is_ok());
+        assert_eq!(tmp.config.data, b"abc\r\n\r\ndef".to_vec());
+        assert_eq!(tmp.config.target_url, "https://example.com/upload");
+
+        tmp.cleanup();
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_raw_crlf_headers_with_lf_lf_in_body() -> io::Result<()> {
+        let mut tmp = TempSetup::new();
+
+        tmp.file
+            .write_all(b"POST /upload HTTP/1.1\r\nHost: example.com\r\n\r\nabc\n\ndef")?;
+
+        parse_request_file(&mut tmp.config).unwrap();
+        assert_eq!(tmp.config.data, b"abc\n\ndef".to_vec());
 
         tmp.cleanup();
         Ok(())

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -405,7 +405,8 @@ pub fn parse_request_file(config: &mut Configuration) -> Result<()> {
 
     // decode only the head; HTTP framing is generally ascii/utf-8 
     // compatible
-    let head = std::str::from_utf8(head_bytes)?;
+    let head = std::str::from_utf8(head_bytes)
+        .map_err(|_| anyhow::anyhow!("Request headers contain invalid UTF-8"))?;
 
     // normalize line endings in the decoded head
     let normalized = head.replace("\r\n", "\n");

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -1442,6 +1442,9 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(tmp.config.data, b"body".to_vec());
+        assert!(tmp.config.headers.contains_key("Host"));
+        assert_eq!(tmp.config.headers.get("Host").unwrap(), "example.com");
+        assert_eq!(tmp.config.user_agent, "test");
 
         tmp.cleanup();
         Ok(())

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -915,7 +915,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Invalid request: Missing head/body CRLF separator"
+            "Invalid request: Missing head/body separator"
         );
 
         tmp.cleanup();
@@ -1355,5 +1355,94 @@ mod tests {
 
         let result = split_query("");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_raw_lf_only_request() -> io::Result<()> {
+        let mut tmp = TempSetup::new();
+
+        tmp.file.write_all(
+            b"GET / HTTP/1.1\nHost: example.com\n\nbody"
+        )?;
+
+        let result = parse_request_file(&mut tmp.config);
+
+        assert!(result.is_ok());
+        assert_eq!(tmp.config.data, b"body".to_vec());
+
+        tmp.cleanup();
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_raw_crlf_request() -> io::Result<()> {
+        let mut tmp = TempSetup::new();
+
+        tmp.file.write_all(
+            b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\nbody"
+        )?;
+
+        let result = parse_request_file(&mut tmp.config);
+
+        assert!(result.is_ok());
+        assert_eq!(tmp.config.data, b"body".to_vec());
+
+        tmp.cleanup();
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_raw_crlf_body_preserved() -> io::Result<()> {
+        let mut tmp = TempSetup::new();
+
+        let body = b"line1\r\nline2\r\nbinary\x00data";
+
+        let mut request = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n".to_vec();
+        request.extend_from_slice(body);
+
+        tmp.file.write_all(&request)?;
+
+        parse_request_file(&mut tmp.config).unwrap();
+
+        assert_eq!(tmp.config.data, body.to_vec());
+
+        tmp.cleanup();
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_raw_lf_headers_crlf_body() -> io::Result<()> {
+        let mut tmp = TempSetup::new();
+
+        let body = b"line1\r\nline2\r\n";
+
+        let mut request = b"GET / HTTP/1.1\nHost: example.com\n\n".to_vec();
+        request.extend_from_slice(body);
+
+        tmp.file.write_all(&request)?;
+
+        parse_request_file(&mut tmp.config).unwrap();
+
+        assert_eq!(tmp.config.data, body.to_vec());
+
+        tmp.cleanup();
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_raw_mixed_newlines_headers() -> io::Result<()> {
+        let mut tmp = TempSetup::new();
+
+        tmp.file.write_all(
+            b"GET / HTTP/1.1\r\nHost: example.com\nUser-Agent: test\r\n\nbody"
+        )?;
+
+        let result = parse_request_file(&mut tmp.config);
+
+        assert!(result.is_ok());
+        assert_eq!(tmp.config.data, b"body".to_vec());
+
+        tmp.cleanup();
+        Ok(())
     }
 }

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -381,35 +381,43 @@ impl ContentType {
 ///   unless overridden by CLI options.
 ///
 pub fn parse_request_file(config: &mut Configuration) -> Result<()> {
-    // read in the file located at config.request_file
+    // read in the file (raw bytes) located at config.request_file
     // parse the file into a Request struct
-    let contents = std::fs::read_to_string(&config.request_file)?;
+    let contents = std::fs::read(&config.request_file)?;
 
     if contents.is_empty() {
         bail!("Empty --request-file file provided");
     }
 
-    // normalize the body to support both CRLF
-    // and LF-only inputs (common when copy-pasting)
-    let normalized = contents.replace("\r\n", "\n");
-    // this should split the body from the request line and headers
-    let lines = normalized.splitn(2, "\n\n").collect::<Vec<&str>>();
+    // find the first header/body separator
+    // prefer \r\n\r\n, otherwise accept \n\n
+    let (sep_idx, sep_len) = if let Some(idx) = contents.windows(4).position(|w| w == b"\r\n\r\n") {
+        (idx, 4)
+    } else if let Some(idx) = contents.windows(2).position(|w| w == b"\n\n") {
+        (idx, 2)
+    } else {
+        bail!("Invalid request: Missing head/body separator")
+    };
 
-    if lines.len() < 2 {
-        bail!("Invalid request: Missing head/body CRLF separator");
-    }
+    // split the request head and body
+    let head_bytes = &contents[..sep_idx];
+    let body_bytes = &contents[sep_idx + sep_len..];
 
-    let head = lines[0];
-    let body = lines[1].as_bytes().to_vec();
+    // decode only the head; HTTP framing is generally ascii/utf-8 
+    // compatible
+    let head = std::str::from_utf8(head_bytes)?;
 
-    // we only want to use the request's body if the user hasn't
+    // normalize line endings in the decoded head
+    let normalized = head.replace("\r\n", "\n");
+
+    // we only want to use the request's body bytes if the user hasn't
     // overridden it on the cli
     if config.data.is_empty() {
-        config.data = body;
+        config.data = body_bytes.to_vec();
     }
 
-    // begin parsing the request line and headers
-    let mut head_parts = head.split("\n");
+    // begin parsing the request line and normalized headers
+    let mut head_parts = normalized.split("\n");
 
     let Some(request_line) = head_parts.next() else {
         bail!("Invalid request: Missing request line");


### PR DESCRIPTION
# Landing a Pull Request (PR)

## Description
Fixes issue #1305 where `--request-file` fails to parse requests that use LF (`\n`) line endings instead of CRLF (`\r\n`). This commonly occurs when copying requests from tools like Burp Suite into a text file.

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123456)
- [x] Code is in its own branch
- [x] Branch name is related to the PR contents
- [x] PR targets main

## Static analysis checks
- [x] All rust files are formatted using `cargo fmt`
- [x] All `clippy` checks pass when running `cargo clippy --all-targets --all-features -- -D warnings -A clippy::mutex-atomic`
- [x] All existing tests pass

## Documentation
- [x] New code is documented using [doc comments](https://doc.rust-lang.org/stable/rust-by-example/meta/doc.html)
- [x] Documentation about your PR is included in the `docs`, as needed. The docs live in a [separate repository](https://epi052.github.io/feroxbuster-docs/). Update the appropriate pages at the links below.
  - [x] update [example config file section](https://epi052.github.io/feroxbuster-docs/configuration/ferox-config-toml/)
  - [x] update [help output section](https://epi052.github.io/feroxbuster-docs/configuration/command-line/)
  - [x] add an [example](https://epi052.github.io/feroxbuster-docs/examples/auto-tune/)

## Additional Tests
- [x] New code is unit tested
- [ ] New code is integration tested, as needed
- [x] New tests pass
